### PR TITLE
Add seed substrate kit

### DIFF
--- a/.substrate/adr/INDEX.md
+++ b/.substrate/adr/INDEX.md
@@ -1,0 +1,4 @@
+# ADR index
+
+| ID | Description | Path |
+|---|---|---|

--- a/.substrate/anti-pattern/INDEX.md
+++ b/.substrate/anti-pattern/INDEX.md
@@ -1,0 +1,5 @@
+# Anti-pattern index
+
+| ID | Description | Path |
+|---|---|---|
+| never-write-all-tests-first | Writing all tests for a slice before writing any implementation leads to test suites that require major rewrites when implementation details shift. | ./never-write-all-tests-first.md |

--- a/.substrate/anti-pattern/never-write-all-tests-first.md
+++ b/.substrate/anti-pattern/never-write-all-tests-first.md
@@ -1,0 +1,34 @@
+---
+id: never-write-all-tests-first
+type: anti-pattern
+description: Writing all tests for a slice before writing any implementation leads to test suites that require major rewrites when implementation details shift.
+created: 2026-05-01
+scope: ["**"]
+---
+
+## Summary
+
+Never write all tests for a slice upfront before beginning any implementation. Write one failing test, make it pass, then write the next. Batch-writing tests first produces a speculative test suite that becomes a liability when early implementation attempts reveal that the initial mental model was wrong.
+
+## Rule
+
+Never write all tests for a slice or feature before writing any implementation code.
+
+## Reason
+
+Because batch-writing tests first creates tight coupling between the test suite and speculative implementation details. When the first implementation attempts reveal that the initial mental model was wrong — and they usually do — you must rewrite both the tests and the code simultaneously. The feedback loop is delayed, the correction cost is multiplied, and the test suite represents a past guess rather than verified behavior.
+
+## Positive example
+
+Correct one-failing-test-at-a-time approach:
+
+```
+1. Write one test: test("renders empty state when list is empty") → RED (fails)
+2. Write the minimum code to make that test pass → GREEN
+3. Refactor if needed; tests still pass
+4. Write next test: test("renders item when list has one entry") → RED (fails)
+5. Write the minimum code to make that test pass → GREEN
+6. Continue until all acceptance criteria are covered by passing tests
+```
+
+Each test is written against code that already exists. The test describes observed behavior, not hoped-for behavior. Implementation never races ahead of verification, and every test that passes represents a real contract — not a wish.

--- a/.substrate/reviewers/INDEX.md
+++ b/.substrate/reviewers/INDEX.md
@@ -1,0 +1,7 @@
+# Reviewer index
+
+| ID | Description | Category | Fires on | Path |
+|---|---|---|---|---|
+| security-sentinel | Flags OWASP top-10 violations, injection vectors, authentication flaws, and insecure credential handling in auth, API, and SQL-touching diffs. | security | auth/, api/, sql | ./security-sentinel.md |
+| code-simplicity-reviewer | Flags YAGNI violations, premature abstractions, dead code, and readability issues in every diff. | quality | always | ./code-simplicity-reviewer.md |
+| architecture-strategist | Evaluates system design decisions, component boundaries, and dependency direction whenever new source files are introduced. | architecture | new-files-in src/ | ./architecture-strategist.md |

--- a/.substrate/reviewers/architecture-strategist.md
+++ b/.substrate/reviewers/architecture-strategist.md
@@ -1,0 +1,24 @@
+---
+id: architecture-strategist
+type: reviewer
+description: Evaluates system design decisions, component boundaries, and dependency direction whenever new source files are introduced.
+created: 2026-05-01
+predicate:
+  new_files_in: ["src/**"]
+category: architecture
+---
+
+## Summary
+
+Architecture specialist that fires when new files appear under `src/`. Checks that new components respect established boundaries, dependency direction is consistent with existing ADRs, and new abstractions align with the vocabulary in `.substrate/vocabulary/`. Consults `.substrate/adr/` before judging choices that may already be settled decisions.
+
+## Review checklist
+
+- [ ] New file is placed in the correct directory; no cross-layer imports that violate established boundaries
+- [ ] Dependency direction is consistent with ADRs and the existing module structure
+- [ ] No circular dependencies introduced by the new file
+- [ ] Public interface of the new module is minimal; internals are unexported or private
+- [ ] New abstractions are consistent with terms already defined in `.substrate/vocabulary/`
+- [ ] If the new file represents a non-obvious structural choice, an ADR candidate is noted in the finding
+- [ ] Component size and responsibility are appropriate; no "god object" responsibility creep
+- [ ] Integration points are defined at module boundaries, not scattered through the internal call graph

--- a/.substrate/reviewers/code-simplicity-reviewer.md
+++ b/.substrate/reviewers/code-simplicity-reviewer.md
@@ -1,0 +1,24 @@
+---
+id: code-simplicity-reviewer
+type: reviewer
+description: Flags YAGNI violations, premature abstractions, dead code, and readability issues in every diff.
+created: 2026-05-01
+predicate:
+  always: true
+category: quality
+---
+
+## Summary
+
+Quality specialist that fires on every diff. Checks for over-engineering, premature generalization, needless abstraction, and complexity that makes future changes harder. Promotes simple, readable code that does exactly what the slice requires and no more — nothing is added for hypothetical future callers.
+
+## Review checklist
+
+- [ ] No abstractions introduced that no current code path exercises
+- [ ] No helper functions, classes, or utilities with exactly one caller that could be inlined
+- [ ] No feature flags, backwards-compatibility shims, or fallbacks for scenarios that cannot happen
+- [ ] Dead code removed; commented-out blocks absent from the diff
+- [ ] Variable and function names are self-documenting; comments explain only non-obvious WHY, not WHAT
+- [ ] Functions are short enough to read without scrolling; each does one thing
+- [ ] No defensive error handling for errors the internal contract already prevents
+- [ ] Duplication is either intentional or noted; three similar lines not prematurely abstracted

--- a/.substrate/reviewers/security-sentinel.md
+++ b/.substrate/reviewers/security-sentinel.md
@@ -1,0 +1,26 @@
+---
+id: security-sentinel
+type: reviewer
+description: Flags OWASP top-10 violations, injection vectors, authentication flaws, and insecure credential handling in auth, API, and SQL-touching diffs.
+created: 2026-05-01
+predicate:
+  any:
+    - paths: ["src/auth/**", "src/api/**", "**/*.sql"]
+category: security
+priority_floor: P2
+---
+
+## Summary
+
+Security specialist that fires on any diff touching authentication code, API handlers, or SQL files. Checks for OWASP top-10 categories including injection, broken authentication, sensitive data exposure, and insecure direct object references. Escalates to P1 for critical vulnerabilities; P2 floor prevents low-severity findings from this reviewer.
+
+## Review checklist
+
+- [ ] No SQL or command injection vectors; parameterized queries or prepared statements used throughout
+- [ ] Authentication state is validated server-side; JWT and session tokens are verified on every protected route
+- [ ] Sensitive data (passwords, tokens, PII) is not logged or returned in API responses
+- [ ] API endpoints enforce authorization checks before acting on any resource
+- [ ] No hardcoded secrets, credentials, or API keys appear in the diff
+- [ ] Input is validated and sanitized at all public API boundaries
+- [ ] Error messages do not leak internal state or stack traces to callers
+- [ ] Cryptographic operations use approved algorithms and adequate key sizes; no custom crypto

--- a/.substrate/solution/INDEX.md
+++ b/.substrate/solution/INDEX.md
@@ -1,0 +1,4 @@
+# Solution index
+
+| ID | Description | Path |
+|---|---|---|

--- a/.substrate/vocabulary/INDEX.md
+++ b/.substrate/vocabulary/INDEX.md
@@ -1,0 +1,4 @@
+# Vocabulary index
+
+| ID | Description | Path |
+|---|---|---|

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Groove substrate
+
+Guidelines for authoring and maintaining substrate entries.
+
+---
+
+## The progressive-disclosure invariant
+
+Every substrate file has two read sites: the **index scan** and the **body fetch**. Both sites must be populated independently.
+
+**Index scan** (`INDEX.md` table row): the always-loaded layer. Skills load only the index at startup — never the full entry bodies. The `description` frontmatter field is what appears in the index table. It must be self-contained: a reader who sees only the index row should know whether this entry is relevant to their current task, without opening the file.
+
+**Body fetch** (the entry file itself): loaded on demand when a skill or agent decides the entry is relevant. The file opens with a `## Summary` block (≤5 lines) that provides a slightly fuller picture — scope, when to consult, key terms. The body below the summary is the full detail: checklists, rules, examples, references.
+
+**Why both?** Because the `description` frontmatter lives in the index row and the `## Summary` block lives in the file body. These two read sites serve different consumers at different moments. Populating only one breaks the invariant: an index-only entry has no usable body; a body-only entry is invisible to index scans and never surfaced by skills that load the always-loaded layer.
+
+When you author a substrate entry:
+
+1. Write the `description` frontmatter field as a single line, ≤200 characters, that stands alone in a table row.
+2. Open the file body with a `## Summary` block of ≤5 lines that expands on the description with scope and context.
+3. Write the full detail below the summary.
+
+---
+
+## Format conventions
+
+| Need | Format |
+|---|---|
+| Prose content | Markdown |
+| File metadata | YAML frontmatter (between `---` delimiters at the top of the file) |
+| Nested structured data inside a file | YAML in a fenced code block (` ```yaml `) |
+| Machine-readable inter-phase artifacts (`findings.json`, `plan.slices.yml`) | JSON (workflow artifacts only) |
+| Substrate storage | **JSON is forbidden** |
+
+**Why JSON is forbidden for substrate:** substrate files are read by agents, diffed by humans, and edited by hand. YAML frontmatter with a Markdown body is the format that serves all three consumers. JSON for substrate would require escaping, loses comments, and is harder to read in a diff. The schemas in `docs/schemas-and-conventions.md` define the allowed frontmatter shapes; the format for all substrate files is Markdown with YAML frontmatter.
+
+---
+
+## Substrate types and required frontmatter
+
+Every substrate file requires these base fields:
+
+```yaml
+id: kebab-case-stable-id
+type: vocabulary | adr | anti-pattern | solution | reviewer
+description: One-line summary; ≤200 characters; appears in INDEX.md
+created: YYYY-MM-DD
+```
+
+Additional required fields by type:
+
+| Type | Extra required fields |
+|---|---|
+| `adr` | `status: accepted \| superseded \| deprecated` |
+| `anti-pattern` | `scope: [glob, ...]` (minItems: 1) |
+| `solution` | `tags: [tag, ...]` (minItems: 1) |
+| `reviewer` | `predicate: <DSL expression>`, `category: string` |
+
+See `docs/schemas-and-conventions.md` for the full schemas and the predicate DSL.
+
+---
+
+## Substrate is append-only
+
+Never silently edit a substrate entry's meaning. If an entry is wrong or stale:
+
+- Add a new entry that supersedes it, with `supersedes: [old-id]` in the frontmatter.
+- Mark the old entry's `status` as `superseded` (for ADRs) or add a `supersedes` back-reference.
+
+Silent edits poison context: agents that loaded the old entry in a prior context window will have seen different content than agents that load the new version. Explicit supersession makes staleness visible and the history debuggable.
+
+---
+
+## Keeping indexes current
+
+Every entry under a substrate type directory must have a row in that type's `INDEX.md`. When you add an entry, add its row. When you supersede an entry, update the index row to reflect the new state. The `validate-substrate` script (when it exists) checks this bidirectionally.


### PR DESCRIPTION
## Summary

- Bootstraps `.substrate/` with five typed `INDEX.md` files (vocabulary, adr, anti-pattern, solution, reviewers) so Groove skills have a working always-loaded layer from first use
- Adds three seed reviewers: `security-sentinel` (fires on auth/api/sql paths, P2 floor), `code-simplicity-reviewer` (fires always), `architecture-strategist` (fires on new files in src/)
- Adds one seed anti-pattern: `never-write-all-tests-first` (repo-wide scope; rule, reason, positive example)
- Adds `docs/CONTRIBUTING.md` explaining the two-read-sites invariant (description frontmatter vs. `## Summary` block) and format conventions (Markdown prose, YAML frontmatter, YAML-in-fenced-blocks, JSON forbidden for substrate)

## Test plan

- [ ] Five `INDEX.md` files exist at `.substrate/{vocabulary,adr,anti-pattern,solution,reviewers}/INDEX.md`
- [ ] Reviewer index has correct 5-column shape (ID, Description, Category, Fires on, Path); all three seed reviewers present
- [ ] Anti-pattern index has correct 3-column shape; `never-write-all-tests-first` row present
- [ ] Each reviewer file has valid frontmatter: `id`, `type: reviewer`, `description`, `created`, `predicate` (DSL-valid), `category`; security-sentinel also has `priority_floor: P2`
- [ ] Anti-pattern file has `scope: ["**"]` and body with rule, reason, positive example
- [ ] `docs/CONTRIBUTING.md` covers two-read-sites rationale and format conventions

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)