### PR TITLE
Add README, implement-issue skill, and shared gh permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh:*)"
+    ]
+  }
+}

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: implement-issue
+description: Implement an issue's acceptance criteria without red-green TDD. Use for issues that build static artifacts (SKILL.md files, templates, seed substrate, configs, docs) or pressure-tested skills where red-green doesn't fit. Reads the issue + agent brief, builds artifacts, verifies acceptance criteria.
+---
+
+# Implement Issue
+
+Implement an issue by building the artifacts its acceptance criteria call for. No red-green-refactor cycle — for that, use `/tdd`.
+
+The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## When to use this vs `/tdd`
+
+Use **this skill** when the deliverable is authored content rather than code logic:
+
+- SKILL.md prompt files (whether unit-tested by fixture or pressure-tested by differential comparison — neither verification style admits red-green-refactor on the prompt itself)
+- Templates, seed substrate, configs, docs, schemas
+- Authored DSL expressions, predicates, frontmatter-driven artifacts
+
+Use **`/tdd`** when the deliverable is executable code logic that admits red-green:
+
+- Validators, parsers, CLI tools, pure functions
+- Library code with deterministic input → output behavior verified by classic unit tests on the *code*
+
+The signal is what changes when a test fails: if you'd edit a `.md` prompt file to fix it, this skill. If you'd edit a `.ts`/`.py`/`.js` source file to fix it, `/tdd`.
+
+Fixture-driven verification of an LLM prompt is not red-green TDD — there's no failing-test-first discipline on the prompt; you write the skill, run the fixture, tweak the skill. Use this skill for that loop.
+
+If the issue body explicitly says **do not use /tdd**, this is the skill to invoke.
+
+## Invocation
+
+The user invokes `/implement-issue <N>` where `<N>` is the issue number. If no argument is given, ask for one.
+
+## Process
+
+### 1. Read the issue and agent brief
+
+```bash
+gh issue view <N> --comments
+```
+
+The triage comment posted by `/triage` contains the agent brief — that is the spec for what to build. If no agent brief exists yet, ask the user to run `/triage <N>` first, or to confirm they want to proceed off the issue body alone.
+
+Parse "Blocked by" — those issues' delivered artifacts on disk are your inputs. If a blocker is unmerged or unfinished, ask the user before proceeding.
+
+### 2. Read project context
+
+Skim. Re-read the specific section when you need an exact shape:
+
+- `CLAUDE.md` (root) — project-wide conventions
+- `docs/skills-prd.md` — v1 skill pack PRD (when working on skills)
+- `docs/schemas-and-conventions.md` — artifact shapes (slice schema, findings schema, substrate frontmatter, predicate DSL, indexes, workflow doc frontmatter)
+- `docs/groove.md` — the loop the skills implement
+- `docs/agents/*.md` — issue tracker / triage label / domain doc conventions
+
+Use the project's domain glossary so artifact names match the project's language; respect ADRs in the area you're touching.
+
+### 3. Implement
+
+Pick the right sub-procedure based on the issue's acceptance criteria. Skills follow the deep-module shape: small public interface (trigger description, inputs, outputs, substrate access declaration in frontmatter), deep implementation (procedure, sub-prompts). Skills are progressively disclosed: SKILL.md is the index entry + summary + procedure; deeper references (`schema.md`, `examples.md`, `failure-modes.md`) are separate files loaded on demand.
+
+#### A. Static artifacts (templates, seed substrate, configs, docs, schemas)
+
+Build directly. Write the file. No fixture. Each acceptance-criteria checkbox is a thing that must be true on disk.
+
+#### B. SKILL.md authored against unit-test fixtures (deterministic black-box check)
+
+When the PRD lists the skill under "unit tests" (e.g. `decompose`, `harvest`, `consolidate`, `substrate-read`, `substrate-write`):
+
+1. Write the unit-test fixture first under `tests/fixtures/<skill>/`. Each fixture: input artifact(s) + expected output (exact shape or property assertions per the PRD's testing section).
+2. Author the SKILL.md.
+3. Run the skill against the fixture; check output against the expectation.
+4. If the check fails, edit the SKILL.md (procedure wording, sub-prompts, examples). Re-run. Iterate until the fixture passes.
+5. The fixture is fixed; the skill is what you tune. Do not edit the fixture to make the skill pass.
+
+This is fixture-driven prompt authoring, not red-green code TDD. There is no failing-test-first discipline on the prompt — you can't write a prompt-failing test before writing the prompt. The fixture is a black-box acceptance check.
+
+#### C. SKILL.md authored against pressure-test fixtures (differential check)
+
+When the PRD lists the skill under "pressure tests" (e.g. `clarify`, `tracer-test`, `review-fanout`):
+
+1. Write the pressure-test fixture first under `tests/fixtures/<skill>/`. Each fixture: scenario prompt, expected output properties, sample bad output.
+2. Run a subagent against the fixture **with** the skill loaded; capture output.
+3. Run the same subagent against the same fixture **without** the skill loaded; capture output.
+4. Compare. The skill must cause measurably better behavior on the fixture.
+5. If the gap isn't real, iterate the SKILL.md procedure until it is. The fixture is fixed; the skill is what you tune.
+
+#### D. SKILL.md with no fixture mandate
+
+When the PRD doesn't specify a test type for the skill (e.g. `research`, `plan-synth`, `slice-impl`, `slice-refactor`, `resolve-finding`, `verify-vs-plan`):
+
+Build directly per (A). Author the SKILL.md against the acceptance criteria. No fixture required unless a criterion explicitly calls for one.
+
+### 4. Verify
+
+Walk through the issue's acceptance criteria checklist literally. Each box is a deliverable. Run any validators referenced in `schemas-and-conventions.md` §9 if they exist; otherwise hand-check shape against the schemas.
+
+If a criterion is ambiguous, ask the user — do not guess.
+
+### 5. Stop
+
+Report what you built (paths + one-line per file) and which acceptance criteria you verified. Do not commit, push, or open a PR unless the user asks.
+
+## Constraints
+
+- **Deep modules.** Small public interface (trigger, inputs, outputs, substrate access declaration), deep implementation. The interface stays stable across implementation rewrites.
+- **Progressive disclosure.** SKILL.md = index entry + summary + procedure. Deeper refs (`schema.md`, `examples.md`, `failure-modes.md`) are separate files loaded on demand. Skills practice their own invariant.
+- **Harness-agnostic.** Never mention Yoke (or any specific harness). Skills compose via shared artifact paths and substrate, not direct calls. The composition graph is the harness's concern, not the skill's.
+- **Format conventions.** Markdown for prose. YAML frontmatter for metadata. YAML in fenced blocks for nested data (slice lists, predicates, items_from configs). JSON only for inter-phase machine artifacts (findings, slice DAG). XML only for in-prompt section delimiters. JSON is forbidden for substrate storage; XML is forbidden everywhere except in-prompt delimiters.
+- **Substrate writes are append-only with explicit supersession.** New entries with `supersedes: [old-id]`; old entries stay on disk. If a skill writes substrate, it goes through `substrate-write` semantics (or follows them by hand if `substrate-write` doesn't exist yet).
+- **One issue at a time.** If acceptance criteria suggest scope creep into a sibling issue, stop and ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,7 @@ Uses the five canonical default label strings. See `docs/agents/triage-labels.md
 ### Domain docs
 
 Single-context repo — one `CONTEXT.md` + `docs/adr/` at the root. See `docs/agents/domain.md`.
+
+### Implementation entrypoint
+
+Issues whose deliverable is authored content (SKILL.md prompts, templates, seed substrate, configs, docs) — not executable code logic — should be implemented via `/implement-issue <N>`, not `/tdd`. The skill lives at `.claude/skills/implement-issue/`. Issue bodies that should not use `/tdd` carry an explicit "do not use /tdd" callout.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,88 @@
+# Groove
+
+A planning-and-implementation loop for AI-assisted software development that ships features and improves the codebase substrate at the same time. Every workflow leaves the project's domain knowledge a little sharper than it found it.
+
+Groove is three things in one repo:
+
+1. **The theory** — a harness-agnostic loop ([`docs/groove.md`](docs/groove.md)) that any developer or agent can follow by hand.
+2. **A skill pack** — an example implementation as composable Claude Code skills ([`docs/skills-prd.md`](docs/skills-prd.md)).
+3. **A Yoke template** — an example harness configuration that runs the skill pack with parallelism, gates, and worktree isolation ([`docs/yoke/`](docs/yoke/)).
+
+Pick the layer you need. Read the theory and run it by hand. Drop the skill pack into Claude Code and run it interactively. Wire the Yoke template in and run it AFK.
+
+## What Groove gives you
+
+- **Substrate that grows with the work.** Every workflow can write 0–4 entries into `.substrate/` (vocabulary, ADRs, anti-patterns, solutions, reviewers). Append-only with explicit supersession — history is preserved, staleness is visible.
+- **Progressive disclosure everywhere.** Substrate, ADRs, and skills are themselves indexed (index → frontmatter description → markdown summary block → body). Agents only load what they need; tokens stop being a tax on knowledge depth.
+- **Vertical slices, not horizontal layers.** Plans decompose into thin tracer-bullet slices with explicit acceptance criteria and `out_of_scope` guards. The slice DAG is built mechanically from file overlap first, then augmented with semantic edges by the agent.
+- **One failing test, then pass it.** No bulk test writing. Each slice gets a single tracer test that passes through every layer.
+- **Specialist review by predicate match.** Reviewers (security, simplicity, architecture, project-grown specialists) declare predicates that fire on diff shape. Small diffs don't pay for unused specialists.
+- **Fresh-context verification.** A separate verifier compares delivered code against the original plan. Drift between plan and implementation gets caught before review, not after.
+- **Cheap restart.** Worktree-isolated runs mean "kill and restart from step 3" is not a punishment.
+
+## Repo layout
+
+```
+docs/
+  groove.md                      The theory (harness-agnostic loop)
+  skills-prd.md                  Skill pack PRD (14 skills, deep-module shape)
+  schemas-and-conventions.md     Artifact shapes (slice, findings, substrate frontmatter, predicate DSL, indexes)
+  agents/                        Per-repo conventions (issue tracker, triage labels, domain docs)
+  yoke/                          Example Yoke config that composes the skill pack
+.claude/
+  skills/                        Project-local Claude Code skills (e.g. implement-issue)
+  settings.json                  Shared Claude Code settings
+.substrate/                      (created on first use) Project knowledge: vocab, ADRs, anti-patterns, solutions, reviewers
+tests/fixtures/                  Per-skill fixtures (unit-test or pressure-test) per PRD §Testing
+```
+
+## How to adopt
+
+### As a developer running Groove by hand
+
+Read [`docs/groove.md`](docs/groove.md). Follow the loop. Write the artifacts the loop names. The substrate seed kit ships in this repo — copy `.substrate/` into your project to bootstrap.
+
+### As a Claude Code user running the skill pack interactively
+
+Install the skills under `.claude/skills/` (or your global skills directory) and invoke them by trigger. Each `SKILL.md` is a deep module with a small public interface:
+
+- `clarify` opens a feature workflow
+- `research` runs three-way parallel research
+- `plan-synth` produces a plan with the slice schema
+- `decompose` builds the slice DAG
+- `tracer-test` writes one failing test
+- `slice-impl` makes it pass
+- `slice-refactor` cleans up (optional)
+- `review-fanout` evaluates reviewer predicates and runs matches
+- `resolve-finding` applies a triage-approved fix
+- `verify-vs-plan` checks delivered code against the plan in fresh context
+- `harvest` writes 0–4 substrate entries on workflow exit
+- `consolidate` runs weekly to promote anti-patterns, merge ADRs, prune stale solutions
+- `substrate-read` and `substrate-write` are the cross-cutting access skills
+
+Pair with project-local helpers like [`/implement-issue`](.claude/skills/implement-issue/SKILL.md) for issues whose deliverable is authored content rather than red-green code logic.
+
+### As a harness implementer running the skill pack AFK
+
+The Yoke template at [`docs/yoke/feature.yml`](docs/yoke/feature.yml) shows how phases, parallelism, gates, and worktrees compose the pack. Yoke is one example — any harness with the right primitives (per-phase prompts, `items_from` iteration, `pre:` / `post:` hooks, retry ladders, worktree isolation) can run the same pack.
+
+## Key conventions
+
+- **Format conventions.** Markdown for prose. YAML frontmatter for metadata. YAML in fenced blocks for nested data (slice lists, predicates). JSON for inter-phase machine artifacts (findings, slice DAG). XML only for in-prompt section delimiters. JSON is forbidden for substrate; XML is forbidden everywhere except in-prompt delimiters.
+- **Substrate writes are append-only with explicit supersession.** New entries with `supersedes: [old-id]`; old entries stay on disk.
+- **Skills are deep modules.** Small public interface (trigger, inputs, outputs, substrate access declaration); deep, mutable implementation. The interface is what other skills, harnesses, and developers depend on.
+- **Skills are harness-agnostic.** They compose via shared artifact paths and substrate, not direct calls. The composition graph is the harness's concern.
+
+## Status
+
+This repo is the planning home for Groove. The theory and schemas are stable; the skill pack and Yoke template are being built out under [GitHub Issues](https://github.com/jdforsythe/groove/issues). See `docs/skills-prd.md` for the v1 plan and the open issues for current state.
+
+## Credits
+
+Groove draws on:
+
+- John Ousterhout's *A Philosophy of Software Design* (deep modules, complexity as cumulative drag)
+- Kent Beck's tracer-bullet TDD (one test, one impl, repeat)
+- Matt Pocock's `setup-matt-pocock-skills` and triage skill set (issue-tracker conventions, AGENT-BRIEF discipline)
+- The Superpowers project's pressure-testing methodology for skills with fuzzy LLM behavior
+- Compound Engineering's substrate idea (system improvements per feature shipped) — though Groove does not enforce a fixed plan-to-review ratio


### PR DESCRIPTION
## Summary

- Add a top-level `README.md` describing Groove's final-state vision (theory + skill pack + Yoke template), three adoption modes, repo layout, and key conventions.
- Add `.claude/skills/implement-issue/` — a project-local Claude Code skill for issues whose deliverable is authored content (SKILL.md prompts, templates, seed substrate, configs, docs). It is the routing target for the 15 impl issues whose bodies carry the "do not use /tdd" callout, since red-green-refactor doesn't fit prompt authoring.
- Add `.claude/settings.json` granting `Bash(gh:*)` so agents can run issue/PR commands without permission friction.
- Update `CLAUDE.md` with a new "Implementation entrypoint" section pointing maintainers and future agents at `/implement-issue` for non-TDD work.

## Why this exists separately from the skill-pack issues

These are repo-level scaffolding (README, project-local skill, settings) — not deliverables of any specific skill-pack issue. Filing them under their own PR keeps the per-issue PRs focused on PRD acceptance criteria.

## Test plan

- [ ] `README.md` renders correctly on GitHub
- [ ] `.claude/skills/implement-issue/SKILL.md` is discoverable when Claude Code runs in this repo (project-local skills directory)
- [ ] `.claude/settings.json` is valid JSON and grants the `Bash(gh:*)` permission as expected
- [ ] `CLAUDE.md` "Implementation entrypoint" section reads cleanly alongside the existing "Agent skills" sections