### PR TITLE
Add substrate-read skill and fixture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,7 @@ Uses the five canonical default label strings. See `docs/agents/triage-labels.md
 ### Domain docs
 
 Single-context repo — one `CONTEXT.md` + `docs/adr/` at the root. See `docs/agents/domain.md`.
+
+## GitHub conventions
+
+All issues and PRs created by agents must be assigned to `jdforsythe`.

--- a/skills/substrate-read/SKILL.md
+++ b/skills/substrate-read/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: substrate-read
+description: >-
+  Read substrate indexes to answer a topic, path glob, or tag query. Fetches
+  progressively deeper (index → summary → body) only as needed. Returns hits
+  ordered by relevance with stop-depth annotation. Invoke whenever a skill
+  needs prior project decisions, vocabulary, anti-patterns, solutions, or
+  reviewers before acting.
+inputs:
+  query: "topic string | path glob (contains / or *) | tag string (prefix: tag:<value>)"
+  type_filter: "optional: vocabulary | adr | anti-pattern | solution | reviewer"
+outputs:
+  hits: "ordered list; each hit: {type, id, description, stop_depth: index|summary|body}"
+substrate_access:
+  pattern: lazy
+  reads:
+    - .substrate/vocabulary/INDEX.md
+    - .substrate/adr/INDEX.md
+    - .substrate/anti-pattern/INDEX.md
+    - .substrate/solution/INDEX.md
+    - .substrate/reviewers/INDEX.md
+  on_demand: entry body files under .substrate/, fetched only when index description is ambiguous relative to the query
+---
+
+## Summary
+
+Accept a query (topic, path glob, or `tag:<value>`) and an optional substrate type filter. Scan the relevant `INDEX.md` files first — always. Fetch an entry's `## Summary` block only when its index description is ambiguous relative to the query. Fetch the full entry body only when `## Summary` is still insufficient. Return hits ordered by relevance, each annotated with the stop-depth actually used (`index`, `summary`, or `body`).
+
+## Procedure
+
+### Step 1 — Parse the query
+
+Classify the query into one of three forms:
+
+- **Topic**: natural language with no `/`, `*`, or `tag:` prefix. Matches against the `description` column in the index. For the reviewer index, also matches against the `Category` column.
+- **Path glob**: contains `/` or `*` (e.g. `src/auth/**`). For reviewers, matches against the `Fires on` index column. For all other types, `scope` is in entry frontmatter — not in the index — so a summary fetch is required.
+- **Tag**: begins with `tag:` followed by a tag value (e.g. `tag:security`). Tags live in entry frontmatter, not index columns, so a summary fetch is required for all types.
+
+If `type_filter` is given, limit all subsequent steps to that substrate type. Otherwise, query all five types.
+
+### Step 2 — Load the index layer
+
+For each applicable substrate type, read its `INDEX.md`. Do not open any entry body files yet.
+
+**Standard index columns** (vocabulary, adr, anti-pattern, solution):
+```
+| ID | Description | Path |
+```
+
+**Reviewer index columns** (adds at-a-glance predicate fields):
+```
+| ID | Description | Category | Fires on | Path |
+```
+
+### Step 3 — Score candidates at the index layer
+
+For each row, compute an initial relevance classification:
+
+**Topic query** — compare query terms against the `description` column (all types) and additionally against `Category` for reviewers:
+- **Clear match**: description directly addresses the query topic → high relevance; STOP at index; include as a hit.
+- **Clear non-match**: description is about something unrelated → relevance zero; STOP at index; exclude.
+- **Ambiguous**: description could plausibly apply or not → mark for summary fetch (Step 4).
+
+**Path glob query**:
+- *Reviewer index*: compare the glob against the `Fires on` column heuristically. A match → high-relevance hit at stop-depth `index`. A non-match → exclude at index.
+- *Other types*: `scope` is not in the standard index columns. Mark all non-reviewer candidates for summary fetch (Step 4), where `scope` frontmatter will be checked.
+
+**Tag query**: Tags are not in any index column. Mark all candidates for summary fetch (Step 4).
+
+### Step 4 — Fetch `## Summary` for marked candidates
+
+For each candidate marked in Step 3, open its entry file (path from the `Path` column). Read the YAML frontmatter and the `## Summary` block. Stop reading at the first heading after `## Summary`.
+
+Apply the following rules based on query form:
+
+**Path glob / non-reviewer types**: check the `scope` frontmatter array against the query glob. If any scope glob overlaps the query → include as a hit at stop-depth `summary`. If no scope matches → exclude.
+
+**Tag query**: check the `tags` frontmatter array for the queried tag value. Exact match → include at stop-depth `summary`. No match → exclude.
+
+**Topic query (ambiguous candidates)**: re-evaluate relevance using the `## Summary` block content.
+- Ambiguity resolved as relevant → include at stop-depth `summary`.
+- Ambiguity resolved as irrelevant → exclude.
+- Still ambiguous after reading `## Summary` → mark for full body fetch (Step 5).
+
+### Step 5 — Fetch full body for remaining ambiguous candidates
+
+For each candidate still marked as ambiguous after Step 4, read the complete entry body. Re-evaluate relevance.
+- Ambiguity resolved as relevant → include at stop-depth `body`.
+- Ambiguity resolved as irrelevant, or body provides no additional signal → exclude.
+
+Do not escalate beyond the full body. If the body cannot resolve ambiguity, exclude the candidate.
+
+### Step 6 — Rank hits by relevance
+
+Collect all included hits across all stop-depths and rank them:
+
+1. **Index hits with direct description match** — highest tier; description unambiguously addresses the query.
+2. **Summary hits with strong match** — middle tier; `## Summary` confirmed clear relevance.
+3. **Body hits** — lower tier; required deep reading to confirm relevance.
+4. Within each tier, partial matches rank below full matches.
+5. Within the same relevance tier and match strength, order by substrate type: `anti-pattern` → `adr` → `solution` → `vocabulary` → `reviewer`. This surfaces constraints first, then decisions, then solutions, then definitions, then reviewers.
+
+### Step 7 — Return hits
+
+Return the ranked hit list. Each hit carries exactly:
+
+```yaml
+hits:
+  - type: <substrate type>
+    id: <entry id>
+    description: <the description value from the index row>
+    stop_depth: index | summary | body
+```
+
+Do not include excluded candidates. Do not fetch entry bodies beyond what the stop-depth decision required — never pre-fetch for convenience.
+
+## Column shape reference
+
+Standard index (vocabulary, adr, anti-pattern, solution):
+```markdown
+| ID | Description | Path |
+|---|---|---|
+| entry-id | One-line summary | ./entry-file.md |
+```
+
+Reviewer index (adds Category and Fires on columns):
+```markdown
+| ID | Description | Category | Fires on | Path |
+|---|---|---|---|---|
+| reviewer-id | One-line reviewer brief | concern-domain | path-summary | ./reviewer-file.md |
+```
+
+The `Fires on` column is a human-readable summary of the reviewer's predicate. Use it for heuristic path glob matching at the index layer. For formal predicate evaluation (outside the scope of this skill), read the entry body's `predicate:` frontmatter field.

--- a/tests/fixtures/substrate-read/scenario.md
+++ b/tests/fixtures/substrate-read/scenario.md
@@ -1,0 +1,191 @@
+# substrate-read fixture
+
+Static specification document. Demonstrates that an agent following the `substrate-read` procedure stops at the correct depth for each candidate and returns hits in the expected order.
+
+---
+
+## Scenario 1 — Topic query, single hit, mixed stop-depths
+
+**Query:** `test approach for vertical slices`
+**Type filter:** none (all five substrate types)
+
+### Substrate state (index layer only)
+
+**vocabulary/INDEX.md** — empty
+
+**adr/INDEX.md** — empty
+
+**anti-pattern/INDEX.md**
+
+| ID | Description | Path |
+|---|---|---|
+| never-write-all-tests-first | Writing all tests for a slice before writing any implementation leads to test suites that require major rewrites when implementation details shift. | ./never-write-all-tests-first.md |
+
+**solution/INDEX.md** — empty
+
+**reviewers/INDEX.md**
+
+| ID | Description | Category | Fires on | Path |
+|---|---|---|---|---|
+| security-sentinel | Flags OWASP top-10 violations, injection vectors, authentication flaws, and insecure credential handling in auth, API, and SQL-touching diffs. | security | auth/, api/, sql | ./security-sentinel.md |
+| code-simplicity-reviewer | Flags YAGNI violations, premature abstractions, dead code, and readability issues in every diff. | quality | always | ./code-simplicity-reviewer.md |
+| architecture-strategist | Evaluates system design decisions, component boundaries, and dependency direction whenever new source files are introduced. | architecture | new-files-in src/ | ./architecture-strategist.md |
+
+### Expected stop-depth per candidate
+
+| Entry ID | Type | Expected stop-depth | In hits? | Reasoning |
+|---|---|---|---|---|
+| never-write-all-tests-first | anti-pattern | index | yes | Description directly mentions "slice" and "tests" — unambiguously relevant. |
+| security-sentinel | reviewer | index | no | Description is about security vulnerabilities; unrelated to test approach. Exclude at index. |
+| code-simplicity-reviewer | reviewer | summary | no | Description mentions YAGNI and premature abstractions — ambiguous (YAGNI could apply to test scope). Fetch ## Summary. Summary confirms this reviewer focuses on production code over-engineering, not test methodology. Exclude after summary. |
+| architecture-strategist | reviewer | index | no | Description is about system design and component boundaries; unrelated to test approach. Exclude at index. |
+
+### Expected output
+
+```yaml
+hits:
+  - type: anti-pattern
+    id: never-write-all-tests-first
+    description: Writing all tests for a slice before writing any implementation leads to test suites that require major rewrites when implementation details shift.
+    stop_depth: index
+```
+
+### What this scenario verifies
+
+- The skill stops at index for a clearly relevant entry (positive match, no deeper fetch).
+- The skill stops at index for clearly irrelevant entries (negative match, no fetch, not included).
+- The skill fetches `## Summary` when the index description is ambiguous.
+- The skill excludes a candidate after `## Summary` when the summary resolves the ambiguity as irrelevant.
+- No full body fetches are triggered — no candidate remains ambiguous after summary.
+- Hits are returned ordered by relevance, not by file order.
+
+---
+
+## Scenario 2 — Topic query, body-depth required, multiple hits
+
+**Query:** `authentication token expiry handling`
+**Type filter:** none (all five substrate types)
+
+### Substrate state (index layer only)
+
+This scenario uses a hypothetical substrate — entries that do not exist in the seed kit but represent realistic project growth.
+
+**adr/INDEX.md** (hypothetical entries)
+
+| ID | Description | Path |
+|---|---|---|
+| auth-token-lifecycle | Decision record for how the system handles token lifecycle events. | ./auth-token-lifecycle.md |
+| session-store-backend | Decision to use Redis over in-process memory for session persistence. | ./session-store-backend.md |
+
+**anti-pattern/INDEX.md** (hypothetical entry in addition to seed)
+
+| ID | Description | Path |
+|---|---|---|
+| never-write-all-tests-first | Writing all tests for a slice before writing any implementation leads to test suites that require major rewrites when implementation details shift. | ./never-write-all-tests-first.md |
+| hardcoded-token-expiry | Embedding token expiry durations as numeric literals rather than named constants causes silent drift between issuance and validation logic. | ./hardcoded-token-expiry.md |
+
+**reviewers/INDEX.md** (seed entries)
+
+| ID | Description | Category | Fires on | Path |
+|---|---|---|---|---|
+| security-sentinel | Flags OWASP top-10 violations, injection vectors, authentication flaws, and insecure credential handling in auth, API, and SQL-touching diffs. | security | auth/, api/, sql | ./security-sentinel.md |
+| code-simplicity-reviewer | Flags YAGNI violations, premature abstractions, dead code, and readability issues in every diff. | quality | always | ./code-simplicity-reviewer.md |
+| architecture-strategist | Evaluates system design decisions, component boundaries, and dependency direction whenever new source files are introduced. | architecture | new-files-in src/ | ./architecture-strategist.md |
+
+### Hypothetical entry body content (for stop-depth verification)
+
+**auth-token-lifecycle.md** (hypothetical):
+
+```
+## Summary
+
+Records the team's decision on token refresh vs. reissue strategies when
+a token becomes invalid. Covers clock-skew tolerance and rotation policy.
+See §Decision for the chosen approach and §Consequences for expiry edge cases.
+```
+
+*(Note: the `## Summary` mentions "invalid" tokens and "rotation policy" but does not explicitly address expiry duration handling — the query term "expiry" appears only in the body's §Consequences section.)*
+
+**Body of auth-token-lifecycle.md** (hypothetical §Consequences excerpt):
+
+> §Consequences: The chosen reissue-on-use policy means the effective expiry window is reset on every authenticated request. Idle sessions expire after the configured `token.max_idle_seconds` value. This directly governs token expiry handling in all auth middleware.
+
+### Expected stop-depth per candidate
+
+| Entry ID | Type | Expected stop-depth | In hits? | Reasoning |
+|---|---|---|---|---|
+| hardcoded-token-expiry | anti-pattern | index | yes | Description directly mentions "token expiry" — unambiguous match. |
+| auth-token-lifecycle | adr | body | yes | Description mentions "token lifecycle events" — ambiguous (lifecycle ≠ expiry specifically). Fetch ## Summary: mentions "invalid" and "rotation" but not "expiry" explicitly — still ambiguous. Fetch body: §Consequences confirms expiry handling is a direct consequence of this decision. Include at body. |
+| session-store-backend | adr | index | no | Description is about storage backend selection; unrelated to expiry handling. Exclude at index. |
+| security-sentinel | reviewer | index | no | Description is about OWASP and injection vectors; does not address expiry semantics. Exclude at index. |
+| never-write-all-tests-first | anti-pattern | index | no | Description is about test writing order; unrelated to token expiry. Exclude at index. |
+| code-simplicity-reviewer | reviewer | index | no | Description is about YAGNI and readability; unrelated to token expiry. Exclude at index. |
+| architecture-strategist | reviewer | index | no | Description is about component boundaries; unrelated to token expiry. Exclude at index. |
+
+### Expected output
+
+```yaml
+hits:
+  - type: anti-pattern
+    id: hardcoded-token-expiry
+    description: Embedding token expiry durations as numeric literals rather than named constants causes silent drift between issuance and validation logic.
+    stop_depth: index
+  - type: adr
+    id: auth-token-lifecycle
+    description: Decision record for how the system handles token lifecycle events.
+    stop_depth: body
+```
+
+Ordering rationale: `hardcoded-token-expiry` ranks first because its description directly names "token expiry" — the exact query topic — and it is an anti-pattern (constraints surface before decisions in the same relevance tier). `auth-token-lifecycle` ranks second: relevance was confirmed only at body depth, placing it in a lower tier than the direct index match.
+
+### What this scenario verifies
+
+- A body-depth fetch is triggered when both the index description and `## Summary` are ambiguous.
+- A body-depth hit is included in the result even though it required the deepest fetch.
+- An index-depth hit outranks a body-depth hit when the index match is more direct.
+- Anti-patterns surface before ADRs in the same relevance tier (constraint-first ordering).
+- The skill does not pre-fetch bodies beyond what ambiguity resolution requires — candidates that were excluded at index are never opened.
+
+---
+
+## Scenario 3 — Path glob query, reviewer index
+
+**Query:** `src/auth/**`
+**Type filter:** reviewer
+
+### Substrate state
+
+**reviewers/INDEX.md** (seed entries — see Scenario 1 for full table)
+
+### Expected stop-depth per candidate
+
+| Entry ID | Expected stop-depth | In hits? | Reasoning |
+|---|---|---|---|
+| security-sentinel | index | yes | `Fires on` column is `auth/, api/, sql` — the query glob `src/auth/**` overlaps `auth/`. Match at index. |
+| code-simplicity-reviewer | index | yes | `Fires on` column is `always` — fires on every diff, including auth diffs. Match at index. |
+| architecture-strategist | index | no | `Fires on` column is `new-files-in src/` — a path match, but no new files are implied by the query; this is a path glob query, not a new-files query. Exclude at index. |
+
+*(Note: For reviewers, the `Fires on` column enables heuristic path glob matching at the index layer without opening any entry body. The architecture-strategist exclusion reflects that its `Fires on` condition is specifically about newly-added files, which is not what a plain path glob query implies. An agent applying this rule should treat `new-files-in X` Fires-on values as non-matching for plain path queries.)*
+
+### Expected output
+
+```yaml
+hits:
+  - type: reviewer
+    id: security-sentinel
+    description: Flags OWASP top-10 violations, injection vectors, authentication flaws, and insecure credential handling in auth, API, and SQL-touching diffs.
+    stop_depth: index
+  - type: reviewer
+    id: code-simplicity-reviewer
+    description: Flags YAGNI violations, premature abstractions, dead code, and readability issues in every diff.
+    stop_depth: index
+```
+
+Ordering: `security-sentinel` ranks first because its `Fires on` and `Description` both specifically name auth — a direct domain match. `code-simplicity-reviewer` ranks second — it fires always, making it a weaker signal for this specific query.
+
+### What this scenario verifies
+
+- Path glob queries against the reviewer index resolve at index stop-depth using the `Fires on` column.
+- No entry body is opened for a reviewer path glob query.
+- `always` reviewers match path glob queries (they fire on every diff).
+- `new-files-in X` Fires-on values do not match plain path glob queries.


### PR DESCRIPTION
## Summary

- Adds `skills/substrate-read/SKILL.md` — the cross-cutting progressive-disclosure skill all other skills call when they need substrate. Implements lazy index-first access with three stop-depths (`index` / `summary` / `body`), handles all five substrate types (reviewer index column shape distinguished from the standard shape), and returns hits ordered by relevance with explicit ranking tiers.
- Adds `tests/fixtures/substrate-read/scenario.md` — three static scenarios: topic query with real seed substrate (index + summary depths), topic query with hypothetical entries demonstrating body-depth fetch, and path glob query against the reviewer index (index-only via `Fires on` column).

Closes #3

## Test plan

- [ ] Verify `skills/substrate-read/SKILL.md` frontmatter has `name`, `description`, `inputs`, `outputs`, and `substrate_access` declaration
- [ ] Verify `## Summary` block is ≤5 lines
- [ ] Verify procedure covers all three query forms (topic, path glob, tag) and all five substrate types
- [ ] Verify stop-depth decision rule is explicit in Steps 3–5
- [ ] Verify fixture at `tests/fixtures/substrate-read/scenario.md` has scenario query, candidates, expected stop-depth per candidate, and expected hit order for each scenario
- [ ] Confirm no Yoke mentions, no JSON in substrate paths, no XML structural tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)