### PR TITLE
feat: add decompose skill

### DIFF
--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: decompose
+description: >-
+  Derive the slice execution DAG from an approved plan. Fires when
+  docs/plans/<workflow_id>.md exists and has been approved. Two phases: (a)
+  mechanical file-overlap edges — derived from touched_paths intersections, no
+  LLM reasoning; (b) agent-added semantic edges with reason fields. Extends the
+  plan doc in place; stores the updated slice YAML in a fenced block.
+inputs:
+  plan_doc: "docs/plans/<workflow_id>.md — workflow-doc frontmatter (type: plan) + ## Summary block + YAML slice list in fenced block"
+outputs:
+  plan_doc: "docs/plans/<workflow_id>.md — same file, slice list extended with semantic_depends_on edges from both phases"
+substrate_access:
+  pattern: none
+  reads: []
+  rationale: "decompose reads only the plan. No substrate access. Substrate signals were already incorporated by plan-synth."
+---
+
+## Summary
+
+Triggered when `docs/plans/<workflow_id>.md` is present and approved. Reads the plan's slice list, derives a dependency DAG in two explicit phases, and writes the extended slice list back into the same plan doc. Phase (a) is deterministic set-intersection over `touched_paths` — no LLM judgment. Phase (b) adds semantic edges with `reason` fields. The validator rejects any output that drops a phase-(a) edge, contains a cycle, or references a non-existent slice id.
+
+## Procedure
+
+### Step 1 — Verify input
+
+Check that `docs/plans/<workflow_id>.md` exists. If absent, stop immediately and output:
+
+```
+Cannot start decompose: docs/plans/<workflow_id>.md not found.
+Run plan-synth first to produce the plan doc, then obtain approval before running decompose.
+```
+
+Do not proceed until the file exists.
+
+### Step 2 — Parse the slice list
+
+Read `docs/plans/<workflow_id>.md`. Locate the fenced `yaml` block under `## Slices`. Parse the YAML. Extract:
+
+- Each slice's `id`
+- Each slice's `touched_paths` array
+
+Confirm every slice has `semantic_depends_on: []` (as produced by `plan-synth`). If any slice already has non-empty `semantic_depends_on`, stop and ask the user whether the plan doc was already partially processed by a previous decompose run. Do not overwrite existing edges silently.
+
+### Step 3 — Phase (a): Derive file-overlap edges (mechanical, no LLM reasoning)
+
+This phase is purely algorithmic. No LLM judgment about file semantics is used.
+
+#### 3a. Compute pairwise path intersections
+
+For every ordered pair of distinct slices `(A, B)`:
+
+1. Compute `overlap = intersection(A.touched_paths, B.touched_paths)`.
+2. Use exact string equality on the glob strings themselves (do not expand globs — compare the written glob patterns as strings).
+3. If `overlap` is non-empty, record an undirected overlap relationship between `A` and `B`, noting the shared paths.
+
+#### 3b. Assign edge direction
+
+For each overlapping pair `(A, B)`, assign a directed dependency edge. Apply this decision rule in order:
+
+1. **Creation vs. mutation:** If one slice's `touched_paths` includes a database migration or schema file (e.g., `src/db/migrations/**`, `*.sql`, `*.prisma`, `schema.*`) and the other does not, the schema slice is the dependency (the non-schema slice depends on it).
+2. **Model vs. service:** If one slice's `touched_paths` includes a model or entity file (e.g., `src/models/**`, `*.entity.*`) and the other touches only service or controller files, the model slice is the dependency.
+3. **Mutual overlap (neither rule applies):** If neither rule resolves direction, record both slices as candidates for direction assignment and flag the pair for phase (b). In the phase (a) output, pick the alphabetically earlier slice id as the dependency — this is a stable placeholder; phase (b) may override the direction but must preserve the edge.
+
+#### 3c. Build the phase-(a) edge list
+
+Collect all directed edges as an ordered list:
+
+```
+phase_a_edges = [
+  { from: "<slice_id>", to: "<dep_slice_id>", shared_paths: ["..."] },
+  ...
+]
+```
+
+This list is the invariant that the validator checks. Every edge in `phase_a_edges` must appear in the final output's `semantic_depends_on` with no `reason` field.
+
+#### 3d. Cycle check after phase (a)
+
+Before proceeding to phase (b), verify the directed edges from step 3b form an acyclic graph. Run a topological sort (Kahn's algorithm or DFS-based). If a cycle exists, stop and report:
+
+```
+Phase (a) produced a cycle. This means two or more slices share touched_paths in a way that
+creates a circular dependency. The plan must be revised before decompose can proceed.
+
+Cycle: <slice_id> → <dep_id> → ... → <slice_id>
+Shared paths involved: <paths>
+
+Options:
+1. Edit the plan to separate the conflicting paths into a new slice.
+2. Re-run decompose after plan approval.
+```
+
+Do not proceed to phase (b) if a cycle exists after phase (a).
+
+### Step 4 — Phase (b): Add semantic edges (agent judgment, additive only)
+
+<constraint>Phase (b) may only ADD edges to semantic_depends_on. It must not remove, modify, or reassign any edge established in phase (a).</constraint>
+
+Review the full slice list — titles, acceptance criteria, and touched_paths — and consider whether any slices have dependencies not captured by file overlap. Examples of semantic (non-file) dependencies:
+
+- Slice B calls an API or function defined by slice A, even if they touch different files.
+- Slice B's implementation requires knowledge of an interface, type, or contract authored in slice A.
+- Slice B can only be tested correctly once slice A's behavior is observable in the running system.
+- Slice B's acceptance criterion references an entity or concept created by slice A.
+
+For each semantic dependency identified:
+
+1. Verify the dependency id references a real slice id in this plan. If not, skip it — do not create a dangling reference.
+2. Verify adding the edge does not create a cycle. If it would, skip it and note the conflict.
+3. Add the edge to `semantic_depends_on` with a `reason` field that explains the non-file dependency in one sentence.
+
+Do not add a semantic edge between two slices just because they are related in theme. The edge must represent a real ordering constraint: slice B cannot proceed (or cannot be correctly tested) until slice A is complete.
+
+#### 4a. Direction resolution for flagged pairs
+
+For any pair flagged in step 3c (mutual overlap, alphabetical placeholder direction), revisit the direction now. Use your understanding of each slice's acceptance criteria and implementation intent to assign the correct direction. The edge must exist in the final output — direction change is permitted, but edge removal is not.
+
+#### 4b. Phase (b) cycle check
+
+After adding all semantic edges, run the topological sort again. If a semantic edge introduced a cycle, remove that edge and note it in the output:
+
+```
+Semantic edge <from> → <to> was skipped: it would create a cycle.
+Reason attempted: "<reason>"
+```
+
+### Step 5 — Integrity check
+
+Before writing output, verify:
+
+1. **All phase-(a) edges present:** For every edge in `phase_a_edges`, the final slice list contains a `semantic_depends_on` entry with matching `id` and no `reason` field.
+2. **Semantic edges have reason:** Every edge added in phase (b) has a non-empty `reason` field.
+3. **No dangling ids:** Every `semantic_depends_on[*].id` in the final output references a real slice `id` in this plan.
+4. **DAG is acyclic:** Topological sort of the final edge set succeeds.
+5. **Slice ids unique and unchanged:** No slice `id` was altered; all original slices are present.
+6. **No other slice fields modified:** Only `semantic_depends_on` arrays were changed. All other fields (`title`, `acceptance_criteria`, `touched_paths`, `out_of_scope`) are identical to the plan doc's original values.
+
+If any check fails, correct the issue before writing output. Do not write a partial or invalid DAG.
+
+### Step 6 — Write output
+
+Update `docs/plans/<workflow_id>.md` in place:
+
+- Keep all frontmatter and prose sections unchanged.
+- Replace only the YAML slice list in the `## Slices` fenced block with the updated slice list.
+- The updated slice list must be valid YAML parseable as a `slices:` array.
+
+Output format within the fenced block:
+
+````markdown
+```yaml
+slices:
+  - id: <id>
+    title: <title>
+    acceptance_criteria:
+      - "<criterion>"
+    touched_paths:
+      - <path>
+    semantic_depends_on:
+      - id: <dep_id>
+      # file-overlap edges have no reason field
+      - id: <dep_id>
+        reason: "<why this slice depends on the other>"
+    out_of_scope:
+      - <guard>
+```
+````
+
+After writing, confirm the output to the user:
+
+```
+decompose complete.
+Plan: docs/plans/<workflow_id>.md
+Slices: <N>
+Phase (a) edges: <count> (file-overlap, no reason field)
+Phase (b) edges: <count> (semantic, with reason field)
+Topological batches:
+  Batch 1 (no dependencies): <slice ids>
+  Batch 2 (depends on batch 1): <slice ids>
+  ...
+```
+
+The plan doc is now ready for the build phase, which consumes the DAG to derive topological batches for parallel execution.
+
+## Constraints
+
+- **No substrate access.** This skill reads only the plan doc. Substrate signals were incorporated by `plan-synth`. Do not open any substrate file.
+- **Two phases are mandatory and explicit.** Phase (a) must complete (including its cycle check) before phase (b) begins. The phases must not be merged or collapsed.
+- **Phase (a) is purely mechanical.** No LLM reasoning about file semantics in phase (a). Only set intersection on `touched_paths` strings and the three-rule direction algorithm.
+- **Phase (b) is additive only.** The agent may add edges and may correct placeholder direction from step 3c, but must not remove any edge that phase (a) established.
+- **File-overlap edges have no `reason` field.** If an edge was derived in phase (a), its entry in `semantic_depends_on` must contain only `id:`. Adding a `reason` field to a file-overlap edge is a schema violation.
+- **Semantic edges must have a `reason` field.** Every edge added in phase (b) must have a non-empty `reason` explaining the non-file dependency.
+- **Output must be acyclic.** If the final DAG contains a cycle, do not write it — report the cycle and stop.
+- **All dep ids must be real.** No dangling references. Check every `id` in `semantic_depends_on` against the slice list before writing.
+- **Extend in place.** Do not create a new file. Update `docs/plans/<workflow_id>.md` in place, changing only the YAML in the `## Slices` fenced block.
+- **Never mention any specific harness.** Skills compose via shared artifact paths; the composition graph is the harness's concern.

--- a/tests/fixtures/decompose/scenario.md
+++ b/tests/fixtures/decompose/scenario.md
@@ -1,0 +1,386 @@
+# decompose fixture
+
+Unit-test specification document. Defines input plan fixtures and expected DAG topology used to verify that an agent following the `decompose` procedure produces the correct slice DAG. Also verifies that file-overlap edges derived in phase (a) cannot be dropped by the agent in phase (b).
+
+The fixtures are fixed. When a scenario fails the check, edit the SKILL.md procedure — not this document.
+
+---
+
+## Scenario 1 — File-overlap edges derived mechanically from touched_paths
+
+**Description:** A plan with four slices where file overlap is unambiguous. Verifies that phase (a) produces exactly the right set of file-overlap edges and that no `reason` field is present on them.
+
+### Input plan (`docs/plans/add-email-notifications.md`)
+
+````markdown
+---
+id: add-email-notifications
+type: plan
+description: Add transactional email notifications triggered by workspace events.
+created: 2026-05-01
+workflow_id: add-email-notifications
+---
+
+## Summary
+
+Four slices covering the data model, delivery service, event wiring, and user preferences
+for transactional email. Each slice can be implemented and tested independently, with
+dependency ordering enforced by the DAG.
+
+## Slices
+
+```yaml
+slices:
+  - id: data-model
+    title: Add notification record and preferences schema
+    acceptance_criteria:
+      - "Given a new workspace event, a notification record is persisted with status=pending."
+    touched_paths:
+      - src/db/migrations/**
+      - src/models/notification.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery logic or retry queues.
+
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - SMS or push delivery channels.
+
+  - id: event-wiring
+    title: Wire workspace events to notification creation
+    acceptance_criteria:
+      - "Given a workspace-member-added event, a notification record is created in the database."
+    touched_paths:
+      - src/events/workspace-events.ts
+      - src/services/notification-creator.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery; only creation is in scope for this slice.
+
+  - id: user-preferences
+    title: Expose user notification preferences API
+    acceptance_criteria:
+      - "Given a PUT /users/:id/notification-preferences request, preferences are persisted and returned."
+    touched_paths:
+      - src/api/users.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Preference-gated delivery filtering (downstream concern).
+```
+````
+
+### Phase (a) — File-overlap derivation (mechanical, no LLM reasoning)
+
+For each pair of slices, compute `intersection(touched_paths_A, touched_paths_B)`. A non-empty intersection means the later slice in topological order depends on the earlier one. Where the dependency direction is ambiguous (both slices share a file and neither is clearly "earlier"), the agent resolves direction using semantic understanding only in phase (b) — phase (a) records the overlap edge without direction assignment and marks it for phase (b) review.
+
+Overlap computation (exact path matching, not glob expansion — globs are matched by string equality at the glob level for this fixture):
+
+| Slice A | Slice B | Shared paths | Edge exists? |
+|---|---|---|---|
+| data-model | delivery-service | `src/models/notification.ts` | yes |
+| data-model | event-wiring | `src/models/notification.ts` | yes |
+| data-model | user-preferences | `src/models/user-preferences.ts` | yes |
+| delivery-service | event-wiring | `src/models/notification.ts` | yes |
+| delivery-service | user-preferences | (none) | no |
+| event-wiring | user-preferences | (none) | no |
+
+### Expected output — after phase (a) only
+
+After phase (a) completes, the slice list has file-overlap edges inserted. No `reason` field is present on any edge. The direction of each edge is: the slice that *creates* a shared resource depends on... — when direction cannot be determined mechanically from file names alone, both directed edge candidates are recorded and flagged for phase (b) to resolve direction.
+
+For this fixture, direction is resolved by the agent in phase (b) based on semantic understanding. The expected final DAG (after both phases) is shown in Scenario 2 below. What phase (a) guarantees: every pair with overlap produces at least one edge in the final output. The validator checks this invariant.
+
+**File-overlap edges that MUST appear in final output (no `reason` field on any of these):**
+
+- `delivery-service` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+- `event-wiring` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+- `user-preferences` depends on `data-model` (shared: `src/models/user-preferences.ts`) — no reason field
+- Either `event-wiring` depends on `delivery-service` OR `delivery-service` depends on `event-wiring` (shared: `src/models/notification.ts`) — whichever direction the agent assigns, it must exist and have no reason field
+
+### What this scenario verifies
+
+- Phase (a) produces file-overlap edges for every pair of slices that share a path.
+- No `reason` field appears on file-overlap edges.
+- Phase (a) produces no edges between slices with disjoint `touched_paths`.
+- The mechanical derivation uses only set intersection on `touched_paths` — no LLM reasoning about file semantics.
+
+---
+
+## Scenario 2 — Full two-phase execution: expected final DAG topology
+
+**Description:** Using the same plan from Scenario 1, the agent runs both phases. Phase (a) produces file-overlap edges; phase (b) adds semantic edges and assigns direction where ambiguous. The result must be a valid, acyclic DAG.
+
+### Expected final output (YAML in fenced block in `docs/plans/add-email-notifications.md`)
+
+```yaml
+slices:
+  - id: data-model
+    title: Add notification record and preferences schema
+    acceptance_criteria:
+      - "Given a new workspace event, a notification record is persisted with status=pending."
+    touched_paths:
+      - src/db/migrations/**
+      - src/models/notification.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery logic or retry queues.
+
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — this is a file-overlap edge
+    out_of_scope:
+      - SMS or push delivery channels.
+
+  - id: event-wiring
+    title: Wire workspace events to notification creation
+    acceptance_criteria:
+      - "Given a workspace-member-added event, a notification record is created in the database."
+    touched_paths:
+      - src/events/workspace-events.ts
+      - src/services/notification-creator.ts
+      - src/models/notification.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — file-overlap edge
+      - id: delivery-service
+        reason: "event-wiring calls the delivery service to dispatch emails after creating records; needs the delivery service's API shape."
+    out_of_scope:
+      - Delivery; only creation is in scope for this slice.
+
+  - id: user-preferences
+    title: Expose user notification preferences API
+    acceptance_criteria:
+      - "Given a PUT /users/:id/notification-preferences request, preferences are persisted and returned."
+    touched_paths:
+      - src/api/users.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — file-overlap edge
+    out_of_scope:
+      - Preference-gated delivery filtering (downstream concern).
+```
+
+### DAG topology assertions
+
+1. `data-model` has no dependencies — it is the root.
+2. `delivery-service` depends on `data-model` via file-overlap edge (no reason).
+3. `event-wiring` depends on `data-model` via file-overlap edge (no reason) AND on `delivery-service` via semantic edge (has reason).
+4. `user-preferences` depends on `data-model` via file-overlap edge (no reason).
+5. The DAG is acyclic — topological sort succeeds: `data-model` → `delivery-service`, `user-preferences` (parallel batch) → `event-wiring`.
+6. All `semantic_depends_on[*].id` values reference real slice ids from the same plan.
+7. No file-overlap edges from phase (a) are absent from the final output.
+
+### What this scenario verifies
+
+- Phase (b) adds semantic edges with `reason` fields where appropriate.
+- Phase (b) does not remove any file-overlap edge from phase (a).
+- The resulting DAG is acyclic.
+- All dependency ids reference real slice ids.
+- The output is stored as YAML in a fenced block within `docs/plans/<workflow_id>.md` (the plan doc is extended in place).
+
+---
+
+## Scenario 3 — Validator rejects agent diff that drops a file-overlap edge
+
+**Description:** The agent produces output that is missing a file-overlap edge that was established in phase (a). The validator must detect and reject this.
+
+### Phase (a) established edges (from Scenario 1)
+
+The following file-overlap edge was mechanically derived and must appear in the final output:
+
+- `delivery-service` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+
+### Invalid agent output (must be rejected)
+
+The agent produces the following `delivery-service` slice entry in its output, dropping the `data-model` file-overlap edge:
+
+```yaml
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - SMS or push delivery channels.
+```
+
+### Validator behavior
+
+The validator compares the agent's output against the phase (a) edge list. For every file-overlap edge derived in phase (a), the validator checks that the corresponding edge appears in `semantic_depends_on` with no `reason` field. If any file-overlap edge is absent, the validator rejects the output with a message identifying the missing edge.
+
+**Expected rejection message:**
+
+```
+Validation failed: file-overlap edge dropped by agent.
+  delivery-service.semantic_depends_on must contain { id: "data-model" } (no reason field).
+  This edge was derived mechanically from shared path: src/models/notification.ts.
+  Agent-phase output may only ADD edges; it must not remove file-overlap edges.
+```
+
+### What this scenario verifies
+
+- The validator reads the phase (a) edge list and confirms all edges are preserved.
+- The validator identifies the specific missing edge and the shared path that produced it.
+- The validator rejects any output that drops a file-overlap edge, even if the agent adds other valid semantic edges.
+- The validator's error message names the slice, the missing dependency id, and the shared path.
+
+---
+
+## Scenario 4 — Cyclic DAG is rejected
+
+**Description:** The agent produces a DAG with a cycle. The validator must detect and reject this.
+
+### Input plan (minimal, three slices)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+      - src/shared.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-b
+    title: Slice B
+    acceptance_criteria:
+      - "Slice B is implemented."
+    touched_paths:
+      - src/b.ts
+      - src/shared.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-c
+    title: Slice C
+    acceptance_criteria:
+      - "Slice C is implemented."
+    touched_paths:
+      - src/c.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+### Invalid agent output (must be rejected)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+      - src/shared.ts
+    semantic_depends_on:
+      - id: slice-b
+      # no reason — file-overlap edge (shared: src/shared.ts)
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-b
+    title: Slice B
+    acceptance_criteria:
+      - "Slice B is implemented."
+    touched_paths:
+      - src/b.ts
+      - src/shared.ts
+    semantic_depends_on:
+      - id: slice-a
+      # no reason — file-overlap edge (shared: src/shared.ts)
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-c
+    title: Slice C
+    acceptance_criteria:
+      - "Slice C is implemented."
+    touched_paths:
+      - src/c.ts
+    semantic_depends_on:
+      - id: slice-a
+        reason: "slice-c semantically depends on slice-a's interface."
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+Note: `slice-a` depends on `slice-b` AND `slice-b` depends on `slice-a` — this is a cycle. In this case, both are mechanically derived file-overlap edges (both slices share `src/shared.ts`). The skill must detect the cycle in phase (a) and resolve it: for any pair of slices where overlap creates a mutual dependency, the agent must choose a direction (not both). The validator rejects any output containing a cycle.
+
+**Expected rejection message:**
+
+```
+Validation failed: DAG contains a cycle.
+  Cycle detected: slice-a → slice-b → slice-a
+  The DAG must be acyclic. Review semantic_depends_on entries and remove the back-edge.
+```
+
+### What this scenario verifies
+
+- The validator runs a topological sort and rejects any output that contains a cycle.
+- The rejection message names the cycle path so the agent can diagnose it.
+- When two slices share a path and would create a mutual file-overlap edge, the skill's procedure instructs the agent to pick a direction — the validator confirms only one direction appears.
+
+---
+
+## Scenario 5 — Dangling dependency id is rejected
+
+**Description:** The agent references a slice id in `semantic_depends_on` that does not exist in the slice list.
+
+### Invalid agent output (must be rejected)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+    semantic_depends_on:
+      - id: nonexistent-slice
+        reason: "slice-a needs something from a slice that does not exist."
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+**Expected rejection message:**
+
+```
+Validation failed: dangling dependency id.
+  slice-a.semantic_depends_on[0].id "nonexistent-slice" does not reference any slice id in this plan.
+  Valid ids: [slice-a]
+```
+
+### What this scenario verifies
+
+- The validator checks every `dependency.id` against the set of slice ids.
+- The validator rejects any output containing a reference to a non-existent slice id.
+- The rejection message names the slice, the array index, the bad id, and the valid ids.


### PR DESCRIPTION
## Summary

- Implements the `decompose` skill: derives a slice execution DAG from an approved plan in two explicit phases
- Phase (a): mechanical file-overlap edges computed by set-intersection on `touched_paths` — no LLM reasoning, purely algorithmic
- Phase (b): agent-added semantic edges with `reason` fields, additive-only (cannot remove phase-a edges)
- Unit-test fixtures under `tests/fixtures/decompose/` covering: topology matching (5-scenario fixture), validator rejection of dropped file-overlap edges, cycle detection, and dangling dependency id rejection

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)