### PR TITLE
feat: add tracer-test skill

### DIFF
--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: decompose
+description: >-
+  Derive the slice execution DAG from an approved plan. Fires when
+  docs/plans/<workflow_id>.md exists and has been approved. Two phases: (a)
+  mechanical file-overlap edges — derived from touched_paths intersections, no
+  LLM reasoning; (b) agent-added semantic edges with reason fields. Extends the
+  plan doc in place; stores the updated slice YAML in a fenced block.
+inputs:
+  plan_doc: "docs/plans/<workflow_id>.md — workflow-doc frontmatter (type: plan) + ## Summary block + YAML slice list in fenced block"
+outputs:
+  plan_doc: "docs/plans/<workflow_id>.md — same file, slice list extended with semantic_depends_on edges from both phases"
+substrate_access:
+  pattern: none
+  reads: []
+  rationale: "decompose reads only the plan. No substrate access. Substrate signals were already incorporated by plan-synth."
+---
+
+## Summary
+
+Triggered when `docs/plans/<workflow_id>.md` is present and approved. Reads the plan's slice list, derives a dependency DAG in two explicit phases, and writes the extended slice list back into the same plan doc. Phase (a) is deterministic set-intersection over `touched_paths` — no LLM judgment. Phase (b) adds semantic edges with `reason` fields. The validator rejects any output that drops a phase-(a) edge, contains a cycle, or references a non-existent slice id.
+
+## Procedure
+
+### Step 1 — Verify input
+
+Check that `docs/plans/<workflow_id>.md` exists. If absent, stop immediately and output:
+
+```
+Cannot start decompose: docs/plans/<workflow_id>.md not found.
+Run plan-synth first to produce the plan doc, then obtain approval before running decompose.
+```
+
+Do not proceed until the file exists.
+
+### Step 2 — Parse the slice list
+
+Read `docs/plans/<workflow_id>.md`. Locate the fenced `yaml` block under `## Slices`. Parse the YAML. Extract:
+
+- Each slice's `id`
+- Each slice's `touched_paths` array
+
+Confirm every slice has `semantic_depends_on: []` (as produced by `plan-synth`). If any slice already has non-empty `semantic_depends_on`, stop and ask the user whether the plan doc was already partially processed by a previous decompose run. Do not overwrite existing edges silently.
+
+### Step 3 — Phase (a): Derive file-overlap edges (mechanical, no LLM reasoning)
+
+This phase is purely algorithmic. No LLM judgment about file semantics is used.
+
+#### 3a. Compute pairwise path intersections
+
+For every ordered pair of distinct slices `(A, B)`:
+
+1. Compute `overlap = intersection(A.touched_paths, B.touched_paths)`.
+2. Use exact string equality on the glob strings themselves (do not expand globs — compare the written glob patterns as strings).
+3. If `overlap` is non-empty, record an undirected overlap relationship between `A` and `B`, noting the shared paths.
+
+#### 3b. Assign edge direction
+
+For each overlapping pair `(A, B)`, assign a directed dependency edge. Apply this decision rule in order:
+
+1. **Creation vs. mutation:** If one slice's `touched_paths` includes a database migration or schema file (e.g., `src/db/migrations/**`, `*.sql`, `*.prisma`, `schema.*`) and the other does not, the schema slice is the dependency (the non-schema slice depends on it).
+2. **Model vs. service:** If one slice's `touched_paths` includes a model or entity file (e.g., `src/models/**`, `*.entity.*`) and the other touches only service or controller files, the model slice is the dependency.
+3. **Mutual overlap (neither rule applies):** If neither rule resolves direction, record both slices as candidates for direction assignment and flag the pair for phase (b). In the phase (a) output, pick the alphabetically earlier slice id as the dependency — this is a stable placeholder; phase (b) may override the direction but must preserve the edge.
+
+#### 3c. Build the phase-(a) edge list
+
+Collect all directed edges as an ordered list:
+
+```
+phase_a_edges = [
+  { from: "<slice_id>", to: "<dep_slice_id>", shared_paths: ["..."] },
+  ...
+]
+```
+
+This list is the invariant that the validator checks. Every edge in `phase_a_edges` must appear in the final output's `semantic_depends_on` with no `reason` field.
+
+#### 3d. Cycle check after phase (a)
+
+Before proceeding to phase (b), verify the directed edges from step 3b form an acyclic graph. Run a topological sort (Kahn's algorithm or DFS-based). If a cycle exists, stop and report:
+
+```
+Phase (a) produced a cycle. This means two or more slices share touched_paths in a way that
+creates a circular dependency. The plan must be revised before decompose can proceed.
+
+Cycle: <slice_id> → <dep_id> → ... → <slice_id>
+Shared paths involved: <paths>
+
+Options:
+1. Edit the plan to separate the conflicting paths into a new slice.
+2. Re-run decompose after plan approval.
+```
+
+Do not proceed to phase (b) if a cycle exists after phase (a).
+
+### Step 4 — Phase (b): Add semantic edges (agent judgment, additive only)
+
+<constraint>Phase (b) may only ADD edges to semantic_depends_on. It must not remove, modify, or reassign any edge established in phase (a).</constraint>
+
+Review the full slice list — titles, acceptance criteria, and touched_paths — and consider whether any slices have dependencies not captured by file overlap. Examples of semantic (non-file) dependencies:
+
+- Slice B calls an API or function defined by slice A, even if they touch different files.
+- Slice B's implementation requires knowledge of an interface, type, or contract authored in slice A.
+- Slice B can only be tested correctly once slice A's behavior is observable in the running system.
+- Slice B's acceptance criterion references an entity or concept created by slice A.
+
+For each semantic dependency identified:
+
+1. Verify the dependency id references a real slice id in this plan. If not, skip it — do not create a dangling reference.
+2. Verify adding the edge does not create a cycle. If it would, skip it and note the conflict.
+3. Add the edge to `semantic_depends_on` with a `reason` field that explains the non-file dependency in one sentence.
+
+Do not add a semantic edge between two slices just because they are related in theme. The edge must represent a real ordering constraint: slice B cannot proceed (or cannot be correctly tested) until slice A is complete.
+
+#### 4a. Direction resolution for flagged pairs
+
+For any pair flagged in step 3c (mutual overlap, alphabetical placeholder direction), revisit the direction now. Use your understanding of each slice's acceptance criteria and implementation intent to assign the correct direction. The edge must exist in the final output — direction change is permitted, but edge removal is not.
+
+#### 4b. Phase (b) cycle check
+
+After adding all semantic edges, run the topological sort again. If a semantic edge introduced a cycle, remove that edge and note it in the output:
+
+```
+Semantic edge <from> → <to> was skipped: it would create a cycle.
+Reason attempted: "<reason>"
+```
+
+### Step 5 — Integrity check
+
+Before writing output, verify:
+
+1. **All phase-(a) edges present:** For every edge in `phase_a_edges`, the final slice list contains a `semantic_depends_on` entry with matching `id` and no `reason` field.
+2. **Semantic edges have reason:** Every edge added in phase (b) has a non-empty `reason` field.
+3. **No dangling ids:** Every `semantic_depends_on[*].id` in the final output references a real slice `id` in this plan.
+4. **DAG is acyclic:** Topological sort of the final edge set succeeds.
+5. **Slice ids unique and unchanged:** No slice `id` was altered; all original slices are present.
+6. **No other slice fields modified:** Only `semantic_depends_on` arrays were changed. All other fields (`title`, `acceptance_criteria`, `touched_paths`, `out_of_scope`) are identical to the plan doc's original values.
+
+If any check fails, correct the issue before writing output. Do not write a partial or invalid DAG.
+
+### Step 6 — Write output
+
+Update `docs/plans/<workflow_id>.md` in place:
+
+- Keep all frontmatter and prose sections unchanged.
+- Replace only the YAML slice list in the `## Slices` fenced block with the updated slice list.
+- The updated slice list must be valid YAML parseable as a `slices:` array.
+
+Output format within the fenced block:
+
+````markdown
+```yaml
+slices:
+  - id: <id>
+    title: <title>
+    acceptance_criteria:
+      - "<criterion>"
+    touched_paths:
+      - <path>
+    semantic_depends_on:
+      - id: <dep_id>
+      # file-overlap edges have no reason field
+      - id: <dep_id>
+        reason: "<why this slice depends on the other>"
+    out_of_scope:
+      - <guard>
+```
+````
+
+After writing, confirm the output to the user:
+
+```
+decompose complete.
+Plan: docs/plans/<workflow_id>.md
+Slices: <N>
+Phase (a) edges: <count> (file-overlap, no reason field)
+Phase (b) edges: <count> (semantic, with reason field)
+Topological batches:
+  Batch 1 (no dependencies): <slice ids>
+  Batch 2 (depends on batch 1): <slice ids>
+  ...
+```
+
+The plan doc is now ready for the build phase, which consumes the DAG to derive topological batches for parallel execution.
+
+## Constraints
+
+- **No substrate access.** This skill reads only the plan doc. Substrate signals were incorporated by `plan-synth`. Do not open any substrate file.
+- **Two phases are mandatory and explicit.** Phase (a) must complete (including its cycle check) before phase (b) begins. The phases must not be merged or collapsed.
+- **Phase (a) is purely mechanical.** No LLM reasoning about file semantics in phase (a). Only set intersection on `touched_paths` strings and the three-rule direction algorithm.
+- **Phase (b) is additive only.** The agent may add edges and may correct placeholder direction from step 3c, but must not remove any edge that phase (a) established.
+- **File-overlap edges have no `reason` field.** If an edge was derived in phase (a), its entry in `semantic_depends_on` must contain only `id:`. Adding a `reason` field to a file-overlap edge is a schema violation.
+- **Semantic edges must have a `reason` field.** Every edge added in phase (b) must have a non-empty `reason` explaining the non-file dependency.
+- **Output must be acyclic.** If the final DAG contains a cycle, do not write it — report the cycle and stop.
+- **All dep ids must be real.** No dangling references. Check every `id` in `semantic_depends_on` against the slice list before writing.
+- **Extend in place.** Do not create a new file. Update `docs/plans/<workflow_id>.md` in place, changing only the YAML in the `## Slices` fenced block.
+- **Never mention any specific harness.** Skills compose via shared artifact paths; the composition graph is the harness's concern.

--- a/skills/tracer-test/SKILL.md
+++ b/skills/tracer-test/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: tracer-test
+description: >-
+  Write exactly ONE failing test targeting a slice's first acceptance criterion.
+  Fires when a slice is ready and no passing test yet covers the first criterion.
+  Never writes implementation. Refuses to run if a passing test already covers
+  the criterion.
+inputs:
+  slice: "A single slice entry from docs/plans/<workflow_id>.md — must have id, title, acceptance_criteria (at minimum one entry), touched_paths, and out_of_scope."
+outputs:
+  test_file: "One test file (new or a single test added to an existing file) within the slice's touched_paths. The test must fail when run because the implementation does not yet exist."
+substrate_access:
+  pattern: eager
+  reads:
+    - .substrate/anti-patterns/INDEX.md
+  on_demand: "Anti-pattern body files for entries whose scope globs match any path in the slice's touched_paths."
+  rationale: "Anti-patterns are read eagerly so that the test file cannot inadvertently encode a known anti-pattern in its test structure or fixtures. Only entries scoped to the slice's touched_paths are fetched."
+---
+
+## Summary
+
+Triggered when a slice is ready (from `decompose`) and no test yet covers its first acceptance criterion. Eagerly loads anti-pattern index; fetches bodies only for anti-patterns scoped to the slice's `touched_paths`. Writes exactly one failing test that targets the first acceptance criterion only. Never writes implementation. Refuses if a passing test for the first criterion already exists. The test is the tracer bullet: it must fail on run, confirming the behavior is not yet implemented.
+
+## Procedure
+
+### Step 1 — Verify preconditions
+
+Before writing anything, perform all three checks in order. Stop at the first failure.
+
+#### 1a. Slice is valid
+
+The slice must have all required fields:
+
+- `id` — non-empty string
+- `title` — non-empty string
+- `acceptance_criteria` — array with at least one entry; `acceptance_criteria[0]` is the **target criterion**
+- `touched_paths` — at least one glob
+- `out_of_scope` — present (may be empty array)
+
+If any required field is missing or `acceptance_criteria` is empty, stop and output:
+
+```
+Cannot start tracer-test: slice <id> is missing required fields.
+Required: id, title, acceptance_criteria (at least one entry), touched_paths, out_of_scope.
+Run plan-synth and decompose to produce a valid slice before running tracer-test.
+```
+
+Do not proceed until the slice is valid.
+
+#### 1b. No passing test already covers the first acceptance criterion
+
+Scan the codebase for tests within the slice's `touched_paths` that target the first criterion. A test "covers" the first criterion when:
+
+- It exists in the repository, AND
+- It passes on the current codebase (i.e., it would not fail if run now), AND
+- Its description or assertion clearly maps to the first acceptance criterion (not just shares a file path).
+
+If a passing test that covers the first criterion is found, stop and output:
+
+```
+tracer-test refused: a passing test already covers the first acceptance criterion.
+Criterion: "<acceptance_criteria[0]>"
+Existing test: <file>:<line> — "<test description>"
+
+This slice is already in GREEN for its first criterion. Run slice-impl (or slice-refactor if
+already green) instead. Do not re-run tracer-test unless the criterion changes.
+```
+
+Do not proceed if a passing test already covers the criterion.
+
+#### 1c. Identify the target test location
+
+Determine where the test should live:
+
+1. Look for an existing test file within the slice's `touched_paths` that is clearly associated with the component under test (same module, same naming convention as other test files in the project).
+2. If one exists, the new test will be added as a single test case within that file.
+3. If no test file exists yet, identify the correct path for a new test file following the project's naming convention (e.g., `<module>.test.ts`, `<module>_test.py`, `test_<module>.py`).
+
+Record the target path — this is where the single test will be written.
+
+### Step 2 — Load scoped anti-patterns (eager)
+
+Read `.substrate/anti-patterns/INDEX.md`. For each anti-pattern entry in the index:
+
+- Check whether the entry's `scope` globs overlap with any path in the slice's `touched_paths`.
+- An overlap exists when at least one glob in the anti-pattern's `scope` matches at least one path in the slice's `touched_paths` (use glob pattern matching, not substring matching).
+
+For each matching anti-pattern, fetch its body file and read it fully. If the index is empty or no anti-patterns match the slice's `touched_paths`, continue without substrate content — the absence of anti-patterns is normal, not an error.
+
+Record the matching anti-patterns. They constrain how the test is written (see Step 3).
+
+### Step 3 — Identify the target criterion
+
+The target criterion is always `acceptance_criteria[0]` — the first entry in the array. Do not target any other criterion in this step.
+
+Read the criterion carefully. It is phrased as an observable behavior ("test-in-prose"). Parse it into two parts:
+
+- **Subject** — what system, module, or function is being tested?
+- **Observable behavior** — what must be true when the test runs?
+
+The test must confirm the observable behavior is absent today (it will fail because the implementation does not yet exist) and confirm it is present after implementation (it will pass when the GREEN phase ships).
+
+Check the `out_of_scope` list. If any `out_of_scope` item could be confused with the first criterion, note it — the test must not inadvertently exercise out-of-scope behavior.
+
+### Step 4 — Write exactly one failing test
+
+Write a single test targeting only the first acceptance criterion. Apply all constraints simultaneously:
+
+#### What the test must do
+
+- Assert the observable behavior described by `acceptance_criteria[0]`.
+- Be runnable with the project's existing test runner (infer from `package.json`, `pyproject.toml`, `Makefile`, or the test files already present in `touched_paths`).
+- Fail when run against the current codebase (because the implementation does not exist yet). If the test would accidentally pass — because the behavior is already partially implemented — revise the assertion to target the unimplemented part specifically.
+- Include a descriptive test name that quotes or closely paraphrases the acceptance criterion. This is the link between the test and the slice.
+
+#### What the test must not do
+
+- **Do not write implementation code.** Do not add production source files, do not fill in function bodies, do not add data models. The only file created or modified is the test file.
+- **Do not test criteria beyond the first.** If the slice has three acceptance criteria, this step covers only `acceptance_criteria[0]`. The remaining criteria are addressed in subsequent `tracer-test` runs (one per red-green cycle).
+- **Do not write setup or teardown that covers out-of-scope behavior.** Fixtures and mocks must be minimal: just enough to run the assertion for the first criterion.
+- **Do not violate any anti-pattern** retrieved in Step 2. If an anti-pattern warns against a specific test structure (e.g., "never use class-level mocks for this module"), use the alternative approach described in the anti-pattern body.
+
+#### Minimal test structure
+
+The test must be the minimum code to run the assertion. Prefer:
+
+- A single `it` / `test` / `def test_` block.
+- Inline minimal fixtures — only what the assertion requires.
+- A comment on the first line of the test block quoting the acceptance criterion it targets.
+
+Avoid:
+
+- `describe` blocks that suggest the test covers an entire module — use a targeted description.
+- Multiple assertions in one test — one criterion, one assertion (or one logical assertion chain).
+- Shared state that would affect other tests.
+
+### Step 5 — Confirm the test will fail
+
+Before writing the file, reason explicitly about why the test will fail on the current codebase:
+
+> The test calls `<function/endpoint/method>` which does not yet exist (or does not yet exhibit `<behavior>`). Running the test now will produce `<expected error: import error / assertion failure / TypeError / etc.>`.
+
+If you cannot identify a reason the test will fail, it is not a tracer bullet — revise the assertion to target something genuinely unimplemented. Do not write a test that passes on the current codebase.
+
+### Step 6 — Write the file
+
+Write exactly one file (the target path from Step 1c). If adding to an existing file, add exactly one new test block — do not modify existing tests.
+
+After writing, output:
+
+```
+tracer-test complete.
+Slice: <id>
+Criterion targeted: "<acceptance_criteria[0]>"
+Test file: <path>
+Expected failure: <one-line explanation of why the test fails now>
+
+Next step: run slice-impl to pass this test.
+```
+
+Do not commit, push, or open a PR. Do not write a second test.
+
+## Constraints
+
+- **One test only.** Exactly one test block (or one test case in an existing file) per run. If the temptation arises to write a second test "while you're in the file," do not. Each additional criterion gets its own `tracer-test` run, its own RED-GREEN cycle.
+- **No implementation.** This step writes test code only. Source files, migration files, and configuration files are out of scope. If any production code must change for the test to be importable (e.g., the module does not exist at all), create an empty stub (with no logic) and note it — but do not implement behavior.
+- **Eagerly scoped anti-patterns.** Anti-patterns must be loaded before the test is written, not after. Do not skip Step 2 even if no anti-patterns are expected.
+- **Refuse on passing test.** If the precondition check in Step 1b finds a passing test covering the first criterion, refuse unconditionally. Do not write a second test alongside the passing one; do not modify the passing test; do not weaken the check.
+- **First criterion only.** The `acceptance_criteria` list is ordered. tracer-test targets index 0. If the user requests targeting a different criterion, decline and explain: run the RED-GREEN cycle for criterion 0 first, then re-invoke tracer-test for criterion 1.
+- **Test must fail.** If the test passes on the current codebase, the precondition is wrong (a passing implementation already exists) or the test is too weak. Both are errors. Revise before writing.
+- **Never mention any specific harness.** Skills compose via shared artifact paths and substrate; the composition graph is the harness's concern.

--- a/tests/fixtures/decompose/scenario.md
+++ b/tests/fixtures/decompose/scenario.md
@@ -1,0 +1,386 @@
+# decompose fixture
+
+Unit-test specification document. Defines input plan fixtures and expected DAG topology used to verify that an agent following the `decompose` procedure produces the correct slice DAG. Also verifies that file-overlap edges derived in phase (a) cannot be dropped by the agent in phase (b).
+
+The fixtures are fixed. When a scenario fails the check, edit the SKILL.md procedure — not this document.
+
+---
+
+## Scenario 1 — File-overlap edges derived mechanically from touched_paths
+
+**Description:** A plan with four slices where file overlap is unambiguous. Verifies that phase (a) produces exactly the right set of file-overlap edges and that no `reason` field is present on them.
+
+### Input plan (`docs/plans/add-email-notifications.md`)
+
+````markdown
+---
+id: add-email-notifications
+type: plan
+description: Add transactional email notifications triggered by workspace events.
+created: 2026-05-01
+workflow_id: add-email-notifications
+---
+
+## Summary
+
+Four slices covering the data model, delivery service, event wiring, and user preferences
+for transactional email. Each slice can be implemented and tested independently, with
+dependency ordering enforced by the DAG.
+
+## Slices
+
+```yaml
+slices:
+  - id: data-model
+    title: Add notification record and preferences schema
+    acceptance_criteria:
+      - "Given a new workspace event, a notification record is persisted with status=pending."
+    touched_paths:
+      - src/db/migrations/**
+      - src/models/notification.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery logic or retry queues.
+
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - SMS or push delivery channels.
+
+  - id: event-wiring
+    title: Wire workspace events to notification creation
+    acceptance_criteria:
+      - "Given a workspace-member-added event, a notification record is created in the database."
+    touched_paths:
+      - src/events/workspace-events.ts
+      - src/services/notification-creator.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery; only creation is in scope for this slice.
+
+  - id: user-preferences
+    title: Expose user notification preferences API
+    acceptance_criteria:
+      - "Given a PUT /users/:id/notification-preferences request, preferences are persisted and returned."
+    touched_paths:
+      - src/api/users.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Preference-gated delivery filtering (downstream concern).
+```
+````
+
+### Phase (a) — File-overlap derivation (mechanical, no LLM reasoning)
+
+For each pair of slices, compute `intersection(touched_paths_A, touched_paths_B)`. A non-empty intersection means the later slice in topological order depends on the earlier one. Where the dependency direction is ambiguous (both slices share a file and neither is clearly "earlier"), the agent resolves direction using semantic understanding only in phase (b) — phase (a) records the overlap edge without direction assignment and marks it for phase (b) review.
+
+Overlap computation (exact path matching, not glob expansion — globs are matched by string equality at the glob level for this fixture):
+
+| Slice A | Slice B | Shared paths | Edge exists? |
+|---|---|---|---|
+| data-model | delivery-service | `src/models/notification.ts` | yes |
+| data-model | event-wiring | `src/models/notification.ts` | yes |
+| data-model | user-preferences | `src/models/user-preferences.ts` | yes |
+| delivery-service | event-wiring | `src/models/notification.ts` | yes |
+| delivery-service | user-preferences | (none) | no |
+| event-wiring | user-preferences | (none) | no |
+
+### Expected output — after phase (a) only
+
+After phase (a) completes, the slice list has file-overlap edges inserted. No `reason` field is present on any edge. The direction of each edge is: the slice that *creates* a shared resource depends on... — when direction cannot be determined mechanically from file names alone, both directed edge candidates are recorded and flagged for phase (b) to resolve direction.
+
+For this fixture, direction is resolved by the agent in phase (b) based on semantic understanding. The expected final DAG (after both phases) is shown in Scenario 2 below. What phase (a) guarantees: every pair with overlap produces at least one edge in the final output. The validator checks this invariant.
+
+**File-overlap edges that MUST appear in final output (no `reason` field on any of these):**
+
+- `delivery-service` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+- `event-wiring` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+- `user-preferences` depends on `data-model` (shared: `src/models/user-preferences.ts`) — no reason field
+- Either `event-wiring` depends on `delivery-service` OR `delivery-service` depends on `event-wiring` (shared: `src/models/notification.ts`) — whichever direction the agent assigns, it must exist and have no reason field
+
+### What this scenario verifies
+
+- Phase (a) produces file-overlap edges for every pair of slices that share a path.
+- No `reason` field appears on file-overlap edges.
+- Phase (a) produces no edges between slices with disjoint `touched_paths`.
+- The mechanical derivation uses only set intersection on `touched_paths` — no LLM reasoning about file semantics.
+
+---
+
+## Scenario 2 — Full two-phase execution: expected final DAG topology
+
+**Description:** Using the same plan from Scenario 1, the agent runs both phases. Phase (a) produces file-overlap edges; phase (b) adds semantic edges and assigns direction where ambiguous. The result must be a valid, acyclic DAG.
+
+### Expected final output (YAML in fenced block in `docs/plans/add-email-notifications.md`)
+
+```yaml
+slices:
+  - id: data-model
+    title: Add notification record and preferences schema
+    acceptance_criteria:
+      - "Given a new workspace event, a notification record is persisted with status=pending."
+    touched_paths:
+      - src/db/migrations/**
+      - src/models/notification.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - Delivery logic or retry queues.
+
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — this is a file-overlap edge
+    out_of_scope:
+      - SMS or push delivery channels.
+
+  - id: event-wiring
+    title: Wire workspace events to notification creation
+    acceptance_criteria:
+      - "Given a workspace-member-added event, a notification record is created in the database."
+    touched_paths:
+      - src/events/workspace-events.ts
+      - src/services/notification-creator.ts
+      - src/models/notification.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — file-overlap edge
+      - id: delivery-service
+        reason: "event-wiring calls the delivery service to dispatch emails after creating records; needs the delivery service's API shape."
+    out_of_scope:
+      - Delivery; only creation is in scope for this slice.
+
+  - id: user-preferences
+    title: Expose user notification preferences API
+    acceptance_criteria:
+      - "Given a PUT /users/:id/notification-preferences request, preferences are persisted and returned."
+    touched_paths:
+      - src/api/users.ts
+      - src/models/user-preferences.ts
+    semantic_depends_on:
+      - id: data-model
+      # no reason field — file-overlap edge
+    out_of_scope:
+      - Preference-gated delivery filtering (downstream concern).
+```
+
+### DAG topology assertions
+
+1. `data-model` has no dependencies — it is the root.
+2. `delivery-service` depends on `data-model` via file-overlap edge (no reason).
+3. `event-wiring` depends on `data-model` via file-overlap edge (no reason) AND on `delivery-service` via semantic edge (has reason).
+4. `user-preferences` depends on `data-model` via file-overlap edge (no reason).
+5. The DAG is acyclic — topological sort succeeds: `data-model` → `delivery-service`, `user-preferences` (parallel batch) → `event-wiring`.
+6. All `semantic_depends_on[*].id` values reference real slice ids from the same plan.
+7. No file-overlap edges from phase (a) are absent from the final output.
+
+### What this scenario verifies
+
+- Phase (b) adds semantic edges with `reason` fields where appropriate.
+- Phase (b) does not remove any file-overlap edge from phase (a).
+- The resulting DAG is acyclic.
+- All dependency ids reference real slice ids.
+- The output is stored as YAML in a fenced block within `docs/plans/<workflow_id>.md` (the plan doc is extended in place).
+
+---
+
+## Scenario 3 — Validator rejects agent diff that drops a file-overlap edge
+
+**Description:** The agent produces output that is missing a file-overlap edge that was established in phase (a). The validator must detect and reject this.
+
+### Phase (a) established edges (from Scenario 1)
+
+The following file-overlap edge was mechanically derived and must appear in the final output:
+
+- `delivery-service` depends on `data-model` (shared: `src/models/notification.ts`) — no reason field
+
+### Invalid agent output (must be rejected)
+
+The agent produces the following `delivery-service` slice entry in its output, dropping the `data-model` file-overlap edge:
+
+```yaml
+  - id: delivery-service
+    title: Implement email delivery service
+    acceptance_criteria:
+      - "Given a notification record in status=pending, the delivery service sends the email and sets status=sent."
+    touched_paths:
+      - src/services/email-delivery.ts
+      - src/models/notification.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - SMS or push delivery channels.
+```
+
+### Validator behavior
+
+The validator compares the agent's output against the phase (a) edge list. For every file-overlap edge derived in phase (a), the validator checks that the corresponding edge appears in `semantic_depends_on` with no `reason` field. If any file-overlap edge is absent, the validator rejects the output with a message identifying the missing edge.
+
+**Expected rejection message:**
+
+```
+Validation failed: file-overlap edge dropped by agent.
+  delivery-service.semantic_depends_on must contain { id: "data-model" } (no reason field).
+  This edge was derived mechanically from shared path: src/models/notification.ts.
+  Agent-phase output may only ADD edges; it must not remove file-overlap edges.
+```
+
+### What this scenario verifies
+
+- The validator reads the phase (a) edge list and confirms all edges are preserved.
+- The validator identifies the specific missing edge and the shared path that produced it.
+- The validator rejects any output that drops a file-overlap edge, even if the agent adds other valid semantic edges.
+- The validator's error message names the slice, the missing dependency id, and the shared path.
+
+---
+
+## Scenario 4 — Cyclic DAG is rejected
+
+**Description:** The agent produces a DAG with a cycle. The validator must detect and reject this.
+
+### Input plan (minimal, three slices)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+      - src/shared.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-b
+    title: Slice B
+    acceptance_criteria:
+      - "Slice B is implemented."
+    touched_paths:
+      - src/b.ts
+      - src/shared.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-c
+    title: Slice C
+    acceptance_criteria:
+      - "Slice C is implemented."
+    touched_paths:
+      - src/c.ts
+    semantic_depends_on: []
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+### Invalid agent output (must be rejected)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+      - src/shared.ts
+    semantic_depends_on:
+      - id: slice-b
+      # no reason — file-overlap edge (shared: src/shared.ts)
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-b
+    title: Slice B
+    acceptance_criteria:
+      - "Slice B is implemented."
+    touched_paths:
+      - src/b.ts
+      - src/shared.ts
+    semantic_depends_on:
+      - id: slice-a
+      # no reason — file-overlap edge (shared: src/shared.ts)
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+
+  - id: slice-c
+    title: Slice C
+    acceptance_criteria:
+      - "Slice C is implemented."
+    touched_paths:
+      - src/c.ts
+    semantic_depends_on:
+      - id: slice-a
+        reason: "slice-c semantically depends on slice-a's interface."
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+Note: `slice-a` depends on `slice-b` AND `slice-b` depends on `slice-a` — this is a cycle. In this case, both are mechanically derived file-overlap edges (both slices share `src/shared.ts`). The skill must detect the cycle in phase (a) and resolve it: for any pair of slices where overlap creates a mutual dependency, the agent must choose a direction (not both). The validator rejects any output containing a cycle.
+
+**Expected rejection message:**
+
+```
+Validation failed: DAG contains a cycle.
+  Cycle detected: slice-a → slice-b → slice-a
+  The DAG must be acyclic. Review semantic_depends_on entries and remove the back-edge.
+```
+
+### What this scenario verifies
+
+- The validator runs a topological sort and rejects any output that contains a cycle.
+- The rejection message names the cycle path so the agent can diagnose it.
+- When two slices share a path and would create a mutual file-overlap edge, the skill's procedure instructs the agent to pick a direction — the validator confirms only one direction appears.
+
+---
+
+## Scenario 5 — Dangling dependency id is rejected
+
+**Description:** The agent references a slice id in `semantic_depends_on` that does not exist in the slice list.
+
+### Invalid agent output (must be rejected)
+
+```yaml
+slices:
+  - id: slice-a
+    title: Slice A
+    acceptance_criteria:
+      - "Slice A is implemented."
+    touched_paths:
+      - src/a.ts
+    semantic_depends_on:
+      - id: nonexistent-slice
+        reason: "slice-a needs something from a slice that does not exist."
+    out_of_scope:
+      - No foreseeable over-build risk for this atomic slice.
+```
+
+**Expected rejection message:**
+
+```
+Validation failed: dangling dependency id.
+  slice-a.semantic_depends_on[0].id "nonexistent-slice" does not reference any slice id in this plan.
+  Valid ids: [slice-a]
+```
+
+### What this scenario verifies
+
+- The validator checks every `dependency.id` against the set of slice ids.
+- The validator rejects any output containing a reference to a non-existent slice id.
+- The rejection message names the slice, the array index, the bad id, and the valid ids.

--- a/tests/fixtures/tracer-test/scenario.md
+++ b/tests/fixtures/tracer-test/scenario.md
@@ -1,0 +1,362 @@
+# tracer-test fixture
+
+Pressure-test specification document. Defines the scenario, expected output properties, and sample bad output used to verify that an agent following the `tracer-test` procedure behaves measurably better than an agent without the skill.
+
+The fixture is fixed. When a scenario fails the differential check, edit the SKILL.md procedure — not this document.
+
+---
+
+## Scenario — "Email notification delivery slice"
+
+**Trigger:** A slice is ready (decompose has completed). No test exists yet for the first acceptance criterion. Run the tracer-test skill.
+
+**Slice (from `docs/plans/add-email-notifications.md`):**
+
+```yaml
+id: notification-delivery
+title: Send email notification when a workspace comment is posted
+acceptance_criteria:
+  - Posting a comment triggers an email to all workspace members who have email notifications enabled
+  - Delivery failures are logged and do not surface to the commenter
+touched_paths:
+  - src/notifications/**
+  - src/comments/**
+  - test/notifications/**
+  - test/comments/**
+semantic_depends_on:
+  - id: notification-preferences
+    reason: Delivery logic reads the preferences schema authored by notification-preferences.
+out_of_scope:
+  - Push notifications
+  - SMS notifications
+  - Notification batching or digests
+  - Unsubscribe flow
+```
+
+**Substrate state (available at start):**
+
+`.substrate/anti-patterns/INDEX.md`:
+
+```
+# Anti-pattern index
+
+| ID | Description | Scope | Path |
+|---|---|---|---|
+| mock-entire-mailer | Never mock the entire mailer module at the class level; mock only the send() method | src/notifications/**, test/notifications/** | ./mock-entire-mailer.md |
+| test-all-criteria-at-once | Never write tests for all acceptance criteria in a single tracer-test step | **/* | ./test-all-criteria-at-once.md |
+```
+
+`.substrate/anti-patterns/mock-entire-mailer.md`:
+
+```markdown
+---
+id: mock-entire-mailer
+type: anti-pattern
+description: Never mock the entire mailer module at the class level; mock only the send() method
+created: 2025-03-10
+scope:
+  - src/notifications/**
+  - test/notifications/**
+tags: [testing, mocking, notifications]
+---
+
+## Summary
+
+Applies to notification tests. Mock only `mailer.send()` at the method level — do not replace
+the whole `Mailer` class. Class-level mocking hides constructor-level side effects and produces
+false positives when the constructor itself is broken.
+
+## Rule
+
+Never replace `Mailer` entirely with a jest mock class or `jest.mock('path/to/mailer')` at the
+module level. Instead, spy on or stub only `mailer.send`.
+
+## Reason
+
+Class-level mocking detaches the test from the real constructor path. If `new Mailer()` throws
+during setup, class-level mocks hide the error; method-level mocks expose it.
+
+## Positive example
+
+```typescript
+// Good: spy on the method, not the class
+const sendSpy = jest.spyOn(mailerInstance, 'send').mockResolvedValue({ ok: true });
+```
+```
+
+`.substrate/anti-patterns/test-all-criteria-at-once.md`:
+
+```markdown
+---
+id: test-all-criteria-at-once
+type: anti-pattern
+description: Never write tests for all acceptance criteria in a single tracer-test step
+created: 2025-03-12
+scope:
+  - "**/*"
+tags: [testing, tdd, groove]
+---
+
+## Summary
+
+Applies to every tracer-test run. Write exactly one test targeting the first unverified
+acceptance criterion. Writing tests for multiple criteria in a single step violates the
+RED-GREEN discipline: each criterion gets its own RED-GREEN cycle.
+
+## Rule
+
+Never write more than one test block per tracer-test invocation.
+
+## Reason
+
+Multiple tests written at once mean multiple failing tests, which makes the GREEN step
+ambiguous: which test should pass first? The discipline is one failing test → one
+implementation step → one green test → optionally refactor → repeat.
+
+## Positive example
+
+One `it` block per tracer-test run. If the slice has three criteria, tracer-test runs
+three times — one per criterion, one per RED-GREEN cycle.
+```
+
+**Codebase state (hypothetical):**
+
+- `src/notifications/` — directory exists but is empty (no delivery logic yet)
+- `src/comments/` — `comment.service.ts` exists with `postComment()` method; does not emit notifications
+- `test/notifications/` — empty directory
+- `test/comments/` — `comment.service.test.ts` exists, tests `postComment()` but does not test notifications
+- `package.json` — uses Jest as test runner; `test/` follows `*.test.ts` naming convention
+
+**No existing test covers the first acceptance criterion** ("Posting a comment triggers an email to all workspace members who have email notifications enabled").
+
+---
+
+## Expected output properties (with-skill behavior)
+
+An agent following the `tracer-test` skill must exhibit ALL of the following properties:
+
+1. **Eager anti-pattern load scoped to touched_paths**: Before writing any test, the agent reads `.substrate/anti-patterns/INDEX.md` and fetches the body of `mock-entire-mailer` (whose scope matches `src/notifications/**` and `test/notifications/**`) and `test-all-criteria-at-once` (whose scope `**/*` matches all paths). The agent does not skip this step even if it believes no anti-patterns are relevant.
+
+2. **Targets only the first acceptance criterion**: The test description and assertions map to criterion 0: "Posting a comment triggers an email to all workspace members who have email notifications enabled." The test does not assert anything about criterion 1 ("Delivery failures are logged...").
+
+3. **Exactly one test block written**: The output contains a single `it` / `test` block. No `describe` suite covering the whole module. No second test case for any other scenario.
+
+4. **Test mocks at method level, not class level**: Respecting the `mock-entire-mailer` anti-pattern, the agent spies on `mailer.send` rather than replacing the `Mailer` class entirely.
+
+5. **No implementation written**: The agent writes only a test file (e.g., `test/notifications/notification-delivery.test.ts` or adds one test to `test/comments/comment.service.test.ts`). It does not write `src/notifications/delivery.service.ts` or fill in `src/comments/comment.service.ts`.
+
+6. **Test will fail on the current codebase**: The agent explicitly states why the test will fail (e.g., `postComment()` does not currently emit notifications, so the `mailer.send` spy will never be called).
+
+7. **Output message format**: After writing, the agent outputs the required summary:
+   - Slice id
+   - Criterion targeted (verbatim)
+   - Test file path
+   - One-line expected failure reason
+   - "Next step: run slice-impl to pass this test."
+
+### Example of compliant test output (with-skill)
+
+```typescript
+// test/notifications/notification-delivery.test.ts
+
+// Criterion: Posting a comment triggers an email to all workspace members who have email notifications enabled
+
+import { postComment } from '../../src/comments/comment.service';
+import { mailer } from '../../src/notifications/mailer';
+
+it('sends an email to each workspace member with notifications enabled when a comment is posted', async () => {
+  const sendSpy = jest.spyOn(mailer, 'send').mockResolvedValue({ ok: true });
+
+  const members = [
+    { id: 'u1', email: 'alice@example.com', notificationsEnabled: true },
+    { id: 'u2', email: 'bob@example.com', notificationsEnabled: false },
+    { id: 'u3', email: 'carol@example.com', notificationsEnabled: true },
+  ];
+
+  await postComment({ workspaceId: 'ws-1', authorId: 'u0', body: 'Hello team', members });
+
+  // Only members with notificationsEnabled: true should receive an email
+  expect(sendSpy).toHaveBeenCalledTimes(2);
+  expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ to: 'alice@example.com' }));
+  expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ to: 'carol@example.com' }));
+});
+```
+
+Agent output after writing:
+
+```
+tracer-test complete.
+Slice: notification-delivery
+Criterion targeted: "Posting a comment triggers an email to all workspace members who have email notifications enabled"
+Test file: test/notifications/notification-delivery.test.ts
+Expected failure: postComment() does not currently call mailer.send(); the spy will never be called, so toHaveBeenCalledTimes(2) will fail with received 0.
+
+Next step: run slice-impl to pass this test.
+```
+
+---
+
+## Sample bad output (without-skill behavior)
+
+An agent **without** the `tracer-test` skill typically exhibits one or more of the following failure modes when given the same slice:
+
+### Bad output example A — writes multiple tests covering all criteria
+
+```typescript
+// test/notifications/notification-delivery.test.ts
+
+describe('NotificationDelivery', () => {
+  it('sends email to workspace members with notifications enabled', async () => {
+    // ... test for criterion 1
+  });
+
+  it('logs delivery failures without surfacing to commenter', async () => {
+    // ... test for criterion 2
+  });
+
+  it('does not send to members with notifications disabled', async () => {
+    // ... additional edge case
+  });
+});
+```
+
+Failure modes present:
+- Writes 3 tests instead of 1
+- Covers criterion 2 ("Delivery failures are logged...") which is out of scope for this step
+- Adds an untargeted edge-case test beyond the acceptance criteria
+- Violates `test-all-criteria-at-once` anti-pattern (if it had been loaded)
+
+### Bad output example B — writes implementation alongside the test
+
+```typescript
+// test/notifications/notification-delivery.test.ts
+
+it('sends email to workspace members with notifications enabled', async () => {
+  // test code
+});
+```
+
+```typescript
+// src/notifications/delivery.service.ts   ← WRONG: implementation written in same step
+
+export async function sendCommentNotification(comment, members) {
+  const enabled = members.filter(m => m.notificationsEnabled);
+  await Promise.all(enabled.map(m => mailer.send({ to: m.email, subject: 'New comment', body: comment.body })));
+}
+```
+
+Failure modes present:
+- Writes implementation in the same step as the test — the RED phase and GREEN phase are collapsed
+- The test now likely passes immediately, eliminating the RED state
+- Violates the core discipline: tracer-test is RED only
+
+### Bad output example C — mocks the entire mailer class
+
+```typescript
+// test/notifications/notification-delivery.test.ts
+
+jest.mock('../../src/notifications/mailer');  // ← class-level mock: violates anti-pattern
+
+import { Mailer } from '../../src/notifications/mailer';
+
+it('sends email to workspace members with notifications enabled', async () => {
+  const mockSend = jest.fn();
+  (Mailer as jest.Mock).mockImplementation(() => ({ send: mockSend }));
+
+  await postComment({ workspaceId: 'ws-1', authorId: 'u0', body: 'Hello', members });
+
+  expect(mockSend).toHaveBeenCalledTimes(2);
+});
+```
+
+Failure modes present:
+- Uses `jest.mock()` at the module level, replacing the entire `Mailer` class
+- Violates `mock-entire-mailer` anti-pattern (not loaded because substrate was skipped)
+- Hides constructor-level errors; produces false positives
+
+### Bad output example D — targets the wrong criterion
+
+```typescript
+// test/notifications/notification-delivery.test.ts
+
+it('logs delivery failures without surfacing to the commenter', async () => {
+  // tests criterion 2, skipping criterion 1
+});
+```
+
+Failure modes present:
+- Targets `acceptance_criteria[1]` instead of `acceptance_criteria[0]`
+- criterion 0 remains uncovered — the slice cannot enter the RED-GREEN cycle correctly
+
+---
+
+## Differential check criteria
+
+Run a subagent with the `tracer-test` skill loaded against the scenario above. Run the same subagent without the skill. Compare outputs using these binary criteria:
+
+| Criterion | With-skill | Without-skill |
+|---|---|---|
+| Reads `.substrate/anti-patterns/INDEX.md` before writing any test | yes | no |
+| Fetches `mock-entire-mailer` body (scope matches touched_paths) | yes | no |
+| Writes exactly one test block | yes | no (typically 2–5 tests) |
+| Test targets only `acceptance_criteria[0]` | yes | no (often covers multiple criteria) |
+| No implementation code written | yes | no (often writes impl alongside) |
+| Mocks at method level (`jest.spyOn`), not class level (`jest.mock`) | yes | no (uses class-level mock) |
+| Test will fail on current codebase (agent explicitly confirms this) | yes | no (often writes a passing test by including impl) |
+| Output summary names the criterion, path, and expected failure reason | yes | no (no structured output) |
+
+The skill passes the differential check when the with-skill run satisfies all eight criteria and the without-skill run fails at least five of them.
+
+---
+
+## Edge case: passing test already exists
+
+**Prompt:**
+
+> The slice is `notification-delivery`. The test `test/notifications/notification-delivery.test.ts` already exists and its first test ("sends email to workspace members with notifications enabled") passes on the current codebase.
+
+**Expected behavior (with-skill):**
+
+The agent outputs:
+
+```
+tracer-test refused: a passing test already covers the first acceptance criterion.
+Criterion: "Posting a comment triggers an email to all workspace members who have email notifications enabled"
+Existing test: test/notifications/notification-delivery.test.ts:5 — "sends email to workspace members with notifications enabled"
+
+This slice is already in GREEN for its first criterion. Run slice-impl (or slice-refactor if
+already green) instead. Do not re-run tracer-test unless the criterion changes.
+```
+
+No file is written. No anti-patterns are loaded (the refusal fires before Step 2).
+
+**Expected behavior (without-skill):**
+
+The agent typically writes a second test alongside the passing one, or overwrites the passing test with a new failing one — both of which corrupt the test suite.
+
+---
+
+## Edge case: user asks to target criterion 2 instead of criterion 1
+
+**Prompt:**
+
+> For slice `notification-delivery`, please write a test for the second criterion ("Delivery failures are logged and do not surface to the commenter") — skip the first one for now.
+
+**Expected behavior (with-skill):**
+
+The agent declines and explains:
+
+```
+tracer-test targets acceptance_criteria[0] only.
+The first criterion ("Posting a comment triggers an email to all workspace members who have email notifications enabled") has not yet been covered.
+
+Run the RED-GREEN cycle for criterion 0 first:
+1. tracer-test → writes a failing test for criterion 0
+2. slice-impl → passes the test for criterion 0
+3. (optional) slice-refactor → refactors while green
+Then re-invoke tracer-test to write a failing test for criterion 1.
+```
+
+**Expected behavior (without-skill):**
+
+The agent complies and writes a test for criterion 2, leaving criterion 1 uncovered and breaking the RED-GREEN ordering.


### PR DESCRIPTION
## Summary
- Implements tracer-test skill: ONE failing test per slice targeting first acceptance criterion
- Pressure-test fixture showing differential vs. without-skill behavior
- Eager substrate access scoped to slice's touched_paths

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)