### PR TITLE
Document three v1 design decisions as ADRs (from issue #2 open questions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Each skill declares its inputs and outputs in its `SKILL.md` frontmatter. They c
 
 The Yoke template at [`docs/yoke/feature.yml`](docs/yoke/feature.yml) shows how phases, parallelism, gates, and worktrees compose the pack. Yoke is one option — any harness with per-phase prompts, `items_from` iteration, `pre:`/`post:` hooks, retry ladders, and worktree isolation can run the same skills.
 
+### Seed substrate
+
+The `.substrate/` directory ships as a single bundle: five `INDEX.md` files (vocabulary, adr, anti-pattern, solution, reviewers) plus three seed reviewer entries and one seed anti-pattern. Copy the whole bundle in one step; there is no per-type installation.
+
+This is intentional. Splitting the seed kit by substrate type (separate seeds for vocabulary, ADRs, anti-patterns, reviewers) would require adopters to pick which slices to install. The cognitive overhead outweighs any benefit — the seed content is small and non-conflicting. Install all of it; delete entries that don't apply to your project; let `harvest` grow the substrate from real signal from there.
+
 ---
 
 ## Step-by-step: running a feature interactively

--- a/docs/adr/0001-harvest-no-signal-threshold.md
+++ b/docs/adr/0001-harvest-no-signal-threshold.md
@@ -1,0 +1,50 @@
+---
+id: harvest-no-signal-threshold
+type: adr
+description: Harvest uses LLM judgment via falsifiable trigger questions, not a configurable numeric threshold
+created: "2026-05-01"
+status: accepted
+tags:
+  - harvest
+  - substrate
+  - skill-interface
+---
+
+## Summary
+
+The `harvest` skill must decide when a workflow has surfaced nothing worth adding to the substrate. This ADR records the decision not to expose a configurable numeric threshold and to rely instead on LLM judgment via the falsifiable trigger questions already in the skill's procedure.
+
+## Context
+
+Issue #2 surfaced this question during v1 planning: *Should the `harvest` no-signal refusal threshold be tunable per project?*
+
+The concern was that different teams have different signal densities. A fast-moving team might want a stricter threshold to avoid substrate noise; a slower team might accept lower signal. A configurable parameter (e.g. `min_entries: 2`) could encode this.
+
+The `harvest` skill's trigger is already implemented as a set of four falsifiable yes/no questions the LLM applies to the workflow trace:
+
+1. Was a domain term used without a definition in the substrate vocabulary?
+2. Was a non-obvious architectural choice made that future agents or maintainers would need context for?
+3. Did an agent over-build in a pattern that would recur and harm future workflows?
+4. Was a problem solved in a reusable way that another workflow might face?
+
+If none of the four answer "yes", the skill writes zero entries and stops.
+
+## Decision
+
+LLM judgment via the existing falsifiable trigger questions is sufficient. No configurable threshold is introduced.
+
+The trigger questions already act as a threshold: they ask whether real signal was surfaced, not whether the signal meets an arbitrary count. Adding a numeric parameter (`min_entries`, `signal_threshold`) would add harness complexity — another value to document, another edge case (what does `min_entries: 0` mean?), another source of drift between teams — without measurable benefit. The falsifiable questions are the threshold.
+
+## Alternatives considered
+
+**Configurable numeric threshold (`min_entries: N`).** Rejected. Introduces a tuneable with unclear semantics. "0 entries" is already the correct outcome when nothing was surfaced; requiring at least N entries would pressure agents to invent entries to meet a floor, which harms substrate quality.
+
+**Mandatory minimum entries per workflow.** Rejected. Same problem as above. Some workflows genuinely surface nothing new. Forcing an entry per workflow fills the substrate with noise.
+
+**Heuristic scoring (e.g., each trigger question contributes a weight).** Rejected. Overcomplicates the judgment without adding reliability. The four binary questions already decompose the decision; scoring them independently would re-introduce calibration as a harness concern.
+
+## Consequences
+
+- The `harvest` skill interface remains simple: trigger, inputs, outputs, no configurable parameters exposed to the harness.
+- Teams that want a stricter policy (e.g., never write vocabulary unless the term appears in at least two slices) encode it in their own harness prompt or in a custom fork of the skill, not in the skill's public interface.
+- The falsifiable trigger questions are the normative mechanism. Any change to the threshold policy is a change to those questions, not a new parameter.

--- a/docs/adr/0002-consolidate-cadence.md
+++ b/docs/adr/0002-consolidate-cadence.md
@@ -1,0 +1,51 @@
+---
+id: consolidate-cadence
+type: adr
+description: Consolidate runs on weekly cron as the default, with signal-based override as an optional addition
+created: "2026-05-01"
+status: accepted
+tags:
+  - consolidate
+  - substrate
+  - harness
+---
+
+## Summary
+
+The `consolidate` skill (substrate hygiene) needs a trigger cadence. This ADR records the decision to default to weekly cron execution and to allow, but not require, a signal-based override trigger for high-velocity projects.
+
+## Context
+
+Issue #2 surfaced this question during v1 planning: *Should `consolidate` cadence be cron-driven (weekly) or signal-driven?*
+
+The `consolidate` skill merges redundant substrate entries, resolves conflicts between vocabulary and ADRs, and marks stale entries as superseded. It is a hygiene pass — it should run regularly even when no individual workflow triggers it.
+
+Two trigger models were considered:
+
+- **Cron-driven (weekly):** A scheduled job runs `consolidate` every week regardless of workflow activity. Predictable; ensures hygiene even when no workflow has completed recently.
+- **Signal-driven:** The harness runs `consolidate` when a threshold is crossed — e.g., when the number of deferred-from-loop issues in GitHub exceeds N, or when a certain number of new substrate entries have accumulated. Responsive; avoids unnecessary runs in quiet periods.
+
+The tension: cron is simple and predictable but may run when there is nothing to consolidate. Signal is responsive but requires the harness to observe and compute the signal, which adds complexity.
+
+## Decision
+
+Weekly cron is the default cadence. Signal-based override is a valid addition for high-velocity projects, but it is not required and is not the default.
+
+The Yoke template shows weekly cron as the primary trigger. A commented-out example shows how to add a signal-based override (e.g., `when deferred-from-loop issues exceed 5`). Projects adopt the override by uncommenting and configuring; they get the default for free.
+
+## Alternatives considered
+
+**Cron-only (no signal override).** Would be simpler but prevents high-velocity projects from getting timely hygiene between weekly runs. A project shipping three features a week could accumulate substrate rot before the next cron fires. Rejected in favor of allowing the override.
+
+**Signal-only (no cron).** Requires every project to define and configure the signal. Projects that don't configure it get no consolidation. The signal threshold is also project-specific (what count triggers it depends on team velocity). Rejected: too much configuration burden for adopters, and the hygiene guarantee disappears.
+
+**Manual-only (no automation).** Suitable for hand-runners who follow the loop without a harness. Already supported — the theory and skill are harness-agnostic. But for automated workflows, manual-only means consolidation is forgotten. Not a viable default.
+
+**Adaptive cadence (more frequent when entries grow fast).** Interesting but overengineered for v1. Requires the harness to track entry growth rate. Deferred.
+
+## Consequences
+
+- The Yoke template shows `consolidate` scheduled as a weekly cron with a commented example of signal-based override.
+- High-velocity projects can add a signal trigger alongside the weekly cron (both triggers coexist — the signal fires when the threshold is crossed, the cron fires regardless).
+- Projects that run the loop by hand run `consolidate` manually at the start of a new week or when they notice substrate drift — no harness configuration needed.
+- Future projects that observe substrate rot between weekly runs have a documented, blessed path to tighten the cadence without modifying the skill.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,8 @@
+# Architecture Decision Records
+
+Domain-level decisions for the Groove repository itself. One file per decision.
+
+| ID | File | Description | Status |
+|---|---|---|---|
+| 0001 | [0001-harvest-no-signal-threshold.md](0001-harvest-no-signal-threshold.md) | Harvest uses LLM judgment via falsifiable trigger questions, not a configurable numeric threshold | accepted |
+| 0002 | [0002-consolidate-cadence.md](0002-consolidate-cadence.md) | Consolidate runs on weekly cron as the default, with signal-based override as an optional addition | accepted |

--- a/skills/defer-finding/SKILL.md
+++ b/skills/defer-finding/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: defer-finding
+description: >-
+  Given a single out-of-scope or P3 finding id from docs/findings.json, file a
+  GitHub issue for future resolution, dedup against existing open issues, append
+  to docs/issues-filed.json, and label with deferred-from-loop. Refuses P1
+  findings. Operates on exactly one finding per invocation.
+inputs:
+  finding_id: "the id of the finding to defer, e.g. fnd-security-sentinel-001"
+  findings_file: "docs/findings.json — produced by review-fanout; skill reads a single entry by id"
+  workflow_id: "the current workflow id; used to construct the deferral reason in the issue body"
+outputs:
+  issue_record: "docs/issues-filed.json — the finding's GitHub issue URL is appended to this array"
+substrate_access:
+  pattern: none
+---
+
+## Summary
+
+Triggered after Gate B triage routes a finding to deferral: out-of-scope P2s and all P3s. Reads the single finding by id from `docs/findings.json` — does not iterate the array. Refuses P1 findings (which are merge blockers, not deferral candidates). Runs a dedup check against open `deferred-from-loop` issues before creating a new one. Files the issue with an actionable title, distilled body, and correct labels. Appends to `docs/issues-filed.json` whether the URL came from a new or pre-existing issue. Operates on exactly one finding per invocation; parallelism comes from running multiple instances against independent findings.
+
+## Procedure
+
+### Step 1 — Read and validate the finding
+
+Read `docs/findings.json`. Locate the entry whose `id` matches the provided `finding_id`. Do not iterate every finding — read the file once and extract the single matching entry.
+
+If no entry with the given `finding_id` exists, stop immediately and output:
+
+```
+Cannot defer: finding '<finding_id>' not found in docs/findings.json.
+Verify the id and re-run, or check that review-fanout has been run for this workflow.
+```
+
+If the found entry has `priority: P1`, stop immediately and output:
+
+```
+Refused: finding '<finding_id>' is priority P1.
+P1 findings are merge blockers and must be resolved, not deferred.
+Route this finding to resolve-finding instead.
+```
+
+Do not modify any files. Do not proceed.
+
+Record these fields from the finding for use in subsequent steps:
+
+- `id`
+- `priority`
+- `in_scope`
+- `reviewer`
+- `title`
+- `description`
+- `location` (optional)
+- `reproducer` (optional)
+- `suggested_fix` (optional)
+
+### Step 2 — Dedup check
+
+Before creating an issue, search for an existing open GitHub issue that already covers this finding.
+
+```bash
+gh issue list --label "deferred-from-loop" --search "<short keyword from finding title>" --state open --json number,title,url,body
+```
+
+Scan the returned issues. A match is a finding whose title and description address the same root cause in the same location — not just surface keyword overlap. Use judgment: if the candidate issue clearly covers the same problem, it is a match. If uncertain, do not treat it as a match — create a new issue.
+
+**If a clearly matching open issue exists:**
+
+Append to `docs/issues-filed.json`:
+
+```json
+{ "finding_id": "<finding_id>", "url": "<existing-issue-url>", "filed_at": "<ISO-8601 datetime>", "dedup": true }
+```
+
+Output:
+
+```
+Deferred (dedup): <finding_id>
+  Matched existing issue: <existing-issue-url>
+  No new issue created.
+  Recorded in docs/issues-filed.json.
+```
+
+Stop. Do not create a new issue.
+
+**If no matching issue exists:** continue to Step 3.
+
+### Step 3 — Create the GitHub issue
+
+Create an issue with `gh issue create`. Do not leave blank labels or omit required fields.
+
+**Title:** Rewrite the finding title to be actionable and reader-friendly. Drop reviewer jargon and internal ids. Format: imperative verb + concrete subject. Example: `finding: "Missing index on notification.user_id"` → issue: `"Add database index on notifications.user_id for read query performance"`.
+
+**Body:** Include all five of the following sections in this order:
+
+1. **Summary** (one paragraph): what the problem is, where it lives, and why it matters. Distill the finding description; do not copy it verbatim.
+2. **Location**: the `location.path` (and line range if present). If no location, write "Location: not location-bound."
+3. **Context**: reviewer that found it (`reviewer` field) and the workflow it came from (`workflow_id` input). Example: `Found by: security-sentinel | Workflow: add-email-notifications-mention`.
+4. **Deferral reason**: one of "Out of scope for workflow `<workflow_id>`" (for out-of-scope P2s) or "P3 — lower-priority improvement" (for P3s). Do not embellish.
+5. **Reproducer** (if available): paste or summarize `finding.reproducer`. If absent, omit the section entirely — do not write "Reproducer: N/A".
+
+**Labels:** Apply all of the following:
+- Map the reviewer's `category` to a matching label (`security`, `performance`, `architecture`, `quality`, or the closest match). Run `gh label list` if uncertain whether the label exists; do not invent labels.
+- `deferred-from-loop` — required; this is how `harvest` finds deferred items later.
+- `priority:P2` or `priority:P3` — matching the finding's priority.
+
+**Assignees:** Assign to the repo's owner or team lead per project conventions. For this repo, assign to `jdforsythe`.
+
+Capture the URL of the created issue.
+
+### Step 4 — Record the URL
+
+Append to `docs/issues-filed.json`. The file is a JSON array. Read it in full, append one new entry, and write it back:
+
+```json
+{ "finding_id": "<finding_id>", "url": "<gh-issue-url>", "filed_at": "<ISO-8601 datetime>", "dedup": false, "labels_applied": ["<label1>", "<label2>"] }
+```
+
+If `docs/issues-filed.json` does not exist, create it as an empty array `[]` before appending.
+
+### Step 5 — Confirm to the user
+
+Output a confirmation:
+
+```
+Deferred: <finding_id> (<priority>)
+  Title:    <issue title>
+  Issue:    <gh-issue-url>
+  Labels:   <comma-separated list>
+  Recorded in docs/issues-filed.json.
+```
+
+## Constraints
+
+- **One finding per invocation.** Never iterate `docs/findings.json` to defer multiple findings. Each invocation targets exactly one `finding_id`.
+- **Refuse P1 findings.** If `priority: P1`, stop at Step 1 without creating any issue.
+- **Dedup before creating.** Always run the dedup check in Step 2. Creating a duplicate issue is the primary failure mode.
+- **Actionable title.** The rewritten title must use an imperative verb and name a concrete subject. Do not copy the finding's raw title.
+- **Distilled body.** Issue bodies are for triage — write to be scanned in seconds. Do not paraphrase the finding verbatim or pad with reviewer metadata.
+- **Required label: `deferred-from-loop`.** This label is how `harvest` detects recurring deferral categories. It must be present on every issued filed by this skill.
+- **Never modify `docs/findings.json`.** The findings file is the output of `review-fanout` and is read-only from the perspective of this skill.
+- **`docs/issues-filed.json` is a JSON array.** Read-append-write atomically; never truncate or overwrite with only the new entry.
+- **Never file P1 findings as issues.** P1 findings that reach this skill indicate a filter error upstream. Refuse and report; do not silently downgrade to P2.


### PR DESCRIPTION
Implements #35.

## Summary
- Adds `docs/adr/0001-harvest-no-signal-threshold.md`: LLM judgment via falsifiable trigger questions is sufficient; no configurable numeric threshold
- Adds `docs/adr/0002-consolidate-cadence.md`: weekly cron as default, signal-based override as optional addition for high-velocity projects
- Adds `docs/adr/README.md`: index of domain ADRs for the Groove repo
- Updates `README.md` with a "Seed substrate" subsection documenting the single-bundle decision (adoption simplicity over per-type granularity)
- Adds `skills/defer-finding/SKILL.md`: the missing defer-finding skill that files GitHub issues for deferred findings
- Posts a comment on issue #2 closing out all three open questions

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)