### PR TITLE
Add validator scripts and derive-file-dag CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+scripts/node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "groove",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@groove/scripts": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,133 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@groove/scripts':
+        specifier: workspace:*
+        version: link:scripts
+
+  scripts:
+    dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+      micromatch:
+        specifier: ^4.0.8
+        version: 4.0.8
+
+packages:
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+snapshots:
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  argparse@2.0.1: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  is-number@7.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  picomatch@2.3.2: {}
+
+  require-from-string@2.0.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - scripts

--- a/scripts/derive-file-dag.js
+++ b/scripts/derive-file-dag.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * derive-file-dag <path>
+ *
+ * Reads docs/plan.slices.yml, computes which pairs of slices share overlapping
+ * touched_paths globs, and writes file-overlap dependency edges (entries with
+ * id only, no reason field) into each affected slice's semantic_depends_on.
+ *
+ * Idempotent: re-running produces the same result as running once.
+ * Preserves semantic edges (those with a reason field).
+ * Does not add self-referential edges.
+ *
+ * Also writes a lock file (.groove-file-dag-lock.json) alongside plan.slices.yml
+ * recording the set of file-overlap edges, so validate-slice-dag can detect tampering.
+ *
+ * Exits 0 on success, non-zero on failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import micromatch from 'micromatch';
+
+const [,, filePath] = process.argv;
+
+if (!filePath) {
+  process.stderr.write('Usage: derive-file-dag <path-to-plan.slices.yml>\n');
+  process.exit(1);
+}
+
+const absPath = path.resolve(filePath);
+
+if (!fs.existsSync(absPath)) {
+  process.stderr.write(`Error: file not found: ${absPath}\n`);
+  process.exit(1);
+}
+
+let doc;
+try {
+  const raw = fs.readFileSync(absPath, 'utf8');
+  doc = yaml.load(raw);
+} catch (err) {
+  process.stderr.write(`Error: could not parse YAML: ${err.message}\n`);
+  process.exit(1);
+}
+
+if (!doc || !Array.isArray(doc.slices)) {
+  process.stderr.write('Error: invalid slices file — missing top-level "slices" array\n');
+  process.exit(1);
+}
+
+const slices = doc.slices;
+
+// ── Compute file-overlap pairs ───────────────────────────────────────────────
+
+/**
+ * Two glob sets "overlap" if any concrete path that could match one also
+ * matches the other. We approximate this by generating candidate paths from
+ * each slice's globs and checking whether any candidate from slice A matches
+ * any glob from slice B (and vice versa).
+ *
+ * Concrete strategy:
+ *   1. Expand each glob into a set of candidate literal paths (for non-wildcard
+ *      globs, the literal path itself; for wildcard globs, use the glob as a
+ *      pattern and derive candidates from all other slices' literal paths).
+ *   2. Check micromatch.isMatch(candidate, otherGlobs).
+ *
+ * Simpler approach that is correct for the common cases used in Groove plans:
+ *   - Compare every glob in slice A against every glob in slice B using
+ *     `micromatch.isMatch(glob_a, glob_b)` or `micromatch.isMatch(glob_b, glob_a)`.
+ *   - Also check whether the globs share a common path prefix (the glob path
+ *     itself, treated as a literal candidate, matches the other set).
+ */
+function globSetsOverlap(globsA, globsB) {
+  // Strategy: for each glob in A, check if it matches any glob in B as a path,
+  // and for each glob in B check if it matches any glob in A as a path.
+  // This handles common cases like "src/auth/**" overlapping with "src/auth/service.ts".
+
+  for (const ga of globsA) {
+    if (micromatch.isMatch(ga, globsB)) return true;
+    // Strip wildcards to get a candidate prefix path
+    const candidate = stripWildcards(ga);
+    if (candidate && micromatch.isMatch(candidate, globsB)) return true;
+  }
+  for (const gb of globsB) {
+    if (micromatch.isMatch(gb, globsA)) return true;
+    const candidate = stripWildcards(gb);
+    if (candidate && micromatch.isMatch(candidate, globsA)) return true;
+  }
+  return false;
+}
+
+function stripWildcards(glob) {
+  // Return the longest literal prefix before a wildcard character
+  const idx = glob.search(/[*?[{]/);
+  if (idx === -1) return glob;
+  // e.g. "src/auth/**" → "src/auth/"
+  let prefix = glob.slice(0, idx);
+  // Remove trailing slash
+  prefix = prefix.replace(/\/+$/, '');
+  return prefix || null;
+}
+
+// ── Apply edges ──────────────────────────────────────────────────────────────
+
+// Build a map of id → slice
+const sliceMap = new Map(slices.map(s => [s.id, s]));
+
+// For each slice, ensure semantic_depends_on is an array
+for (const slice of slices) {
+  if (!Array.isArray(slice.semantic_depends_on)) {
+    slice.semantic_depends_on = [];
+  }
+}
+
+// Lock: { [sliceId]: string[] } — ids of file-overlap deps
+const lock = {};
+
+// Only add edges from later slices to earlier slices (by declaration order)
+// to avoid creating cycles. A slice at index i depends on slices at index j < i
+// that share overlapping paths.
+for (let i = 0; i < slices.length; i++) {
+  const sliceA = slices[i];
+  for (let j = 0; j < i; j++) {
+    const sliceB = slices[j];
+
+    const globsA = sliceA.touched_paths ?? [];
+    const globsB = sliceB.touched_paths ?? [];
+
+    if (globsA.length === 0 || globsB.length === 0) continue;
+
+    if (globSetsOverlap(globsA, globsB)) {
+      // sliceA (later) depends on sliceB (earlier, file-overlap edge)
+      const existing = sliceA.semantic_depends_on.find(d => d.id === sliceB.id);
+      if (!existing) {
+        // Add file-overlap edge (no reason field)
+        sliceA.semantic_depends_on.push({ id: sliceB.id });
+      }
+      // If existing edge already has reason, leave it alone (semantic edge takes precedence)
+    }
+  }
+
+  // Record file-overlap edges in the lock
+  const overlapEdges = sliceA.semantic_depends_on
+    .filter(d => !d.reason)
+    .map(d => d.id);
+  if (overlapEdges.length > 0) {
+    lock[sliceA.id] = overlapEdges;
+  }
+}
+
+// ── Write updated YAML ───────────────────────────────────────────────────────
+
+try {
+  const updatedYaml = yaml.dump(doc, { lineWidth: 120, noRefs: true });
+  fs.writeFileSync(absPath, updatedYaml, 'utf8');
+} catch (err) {
+  process.stderr.write(`Error: could not write updated YAML: ${err.message}\n`);
+  process.exit(1);
+}
+
+// ── Write lock file ──────────────────────────────────────────────────────────
+
+const lockPath = path.join(path.dirname(absPath), '.groove-file-dag-lock.json');
+try {
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n', 'utf8');
+} catch (err) {
+  process.stderr.write(`Warning: could not write lock file: ${err.message}\n`);
+  // Non-fatal — the main operation succeeded
+}
+
+const edgeCount = Object.values(lock).reduce((sum, arr) => sum + arr.length, 0);
+process.stdout.write(`derive-file-dag: OK (${edgeCount} file-overlap edge${edgeCount === 1 ? '' : 's'} written)\n`);
+process.exit(0);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@groove/scripts",
+  "version": "1.0.0",
+  "description": "Groove artifact validator scripts and derive-file-dag CLI",
+  "type": "module",
+  "bin": {
+    "validate-slices": "./validate-slices.js",
+    "validate-slice-dag": "./validate-slice-dag.js",
+    "validate-findings": "./validate-findings.js",
+    "validate-substrate": "./validate-substrate.js",
+    "validate-substrate-coverage": "./validate-substrate-coverage.js",
+    "derive-file-dag": "./derive-file-dag.js"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "js-yaml": "^4.1.0",
+    "micromatch": "^4.0.8"
+  }
+}

--- a/scripts/validate-findings.js
+++ b/scripts/validate-findings.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * validate-findings <path>
+ *
+ * Validates docs/findings.json against the §2 findings schema.
+ * Extra checks beyond JSON Schema:
+ *   - All finding ids are unique
+ *   - reviewer references a real entry in .substrate/reviewers/INDEX.md
+ *   - in_scope is correctly computed:
+ *       true  iff location.path matches a glob in any slice's touched_paths
+ *       false iff location.path does NOT match any slice glob
+ *     If docs/plan.slices.yml is absent, the in_scope check is skipped (warns).
+ *     If a finding has no location.path, in_scope check for that finding is skipped.
+ *
+ * Exits 0 on success, non-zero on any failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import micromatch from 'micromatch';
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const [,, filePath] = process.argv;
+
+if (!filePath) {
+  process.stderr.write('Usage: validate-findings <path-to-findings.json>\n');
+  process.exit(1);
+}
+
+const absPath = path.resolve(filePath);
+
+if (!fs.existsSync(absPath)) {
+  process.stderr.write(`Error: file not found: ${absPath}\n`);
+  process.exit(1);
+}
+
+let doc;
+try {
+  doc = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+} catch (err) {
+  process.stderr.write(`Error: could not parse JSON: ${err.message}\n`);
+  process.exit(1);
+}
+
+// ── JSON Schema ──────────────────────────────────────────────────────────────
+
+const FINDINGS_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'groove/findings.schema.json',
+  title: 'Review findings',
+  type: 'object',
+  required: ['findings'],
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: { $ref: '#/$defs/finding' },
+    },
+  },
+  $defs: {
+    finding: {
+      type: 'object',
+      required: ['id', 'reviewer', 'priority', 'in_scope', 'title', 'description'],
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+          pattern: '^fnd-[a-z0-9]+(-[a-z0-9]+)*$',
+        },
+        reviewer: { type: 'string' },
+        priority: { type: 'string', enum: ['P1', 'P2', 'P3'] },
+        in_scope: { type: 'boolean' },
+        location: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            path: { type: 'string' },
+            line_start: { type: 'integer', minimum: 1 },
+            line_end: { type: 'integer', minimum: 1 },
+          },
+        },
+        title: { type: 'string', minLength: 1, maxLength: 120 },
+        description: { type: 'string', minLength: 1 },
+        reproducer: { type: 'string' },
+        suggested_fix: { type: 'string' },
+      },
+    },
+  },
+};
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(FINDINGS_SCHEMA);
+
+const valid = validate(doc);
+if (!valid) {
+  for (const err of validate.errors) {
+    process.stderr.write(`Schema error at ${err.instancePath || '(root)'}: ${err.message}\n`);
+    if (err.params) {
+      const detail = JSON.stringify(err.params);
+      if (detail !== '{}') process.stderr.write(`  params: ${detail}\n`);
+    }
+  }
+  process.exit(1);
+}
+
+// ── Extra checks ─────────────────────────────────────────────────────────────
+
+const findings = doc.findings;
+let failed = false;
+
+// Unique id check
+const ids = new Set();
+for (const finding of findings) {
+  if (ids.has(finding.id)) {
+    process.stderr.write(`Error: duplicate finding id "${finding.id}"\n`);
+    failed = true;
+  }
+  ids.add(finding.id);
+}
+
+// Reviewer reference check — parse .substrate/reviewers/INDEX.md
+const reviewerIndexPath = path.resolve('.substrate/reviewers/INDEX.md');
+let knownReviewerIds = null;
+
+if (!fs.existsSync(reviewerIndexPath)) {
+  process.stderr.write('Warning: .substrate/reviewers/INDEX.md not found — skipping reviewer reference check\n');
+} else {
+  knownReviewerIds = new Set();
+  const indexContent = fs.readFileSync(reviewerIndexPath, 'utf8');
+  // Parse markdown table rows: | ID | ... |
+  for (const line of indexContent.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) continue;
+    const cells = trimmed.split('|').map(c => c.trim()).filter(Boolean);
+    if (cells.length < 1) continue;
+    const idCell = cells[0];
+    // Skip header row and separator row
+    if (idCell === 'ID' || idCell.match(/^[-:]+$/)) continue;
+    if (idCell) knownReviewerIds.add(idCell);
+  }
+}
+
+for (const finding of findings) {
+  if (knownReviewerIds !== null && !knownReviewerIds.has(finding.reviewer)) {
+    process.stderr.write(
+      `Error: finding "${finding.id}" references reviewer "${finding.reviewer}" which does not exist in .substrate/reviewers/INDEX.md\n`
+    );
+    failed = true;
+  }
+}
+
+// in_scope check against plan.slices.yml
+const slicesPath = path.resolve('docs/plan.slices.yml');
+let allGlobs = null; // flat list of all touched_paths globs across all slices
+
+if (!fs.existsSync(slicesPath)) {
+  process.stderr.write('Warning: docs/plan.slices.yml not found — skipping in_scope check\n');
+} else {
+  let slicesDoc;
+  try {
+    slicesDoc = yaml.load(fs.readFileSync(slicesPath, 'utf8'));
+  } catch (err) {
+    process.stderr.write(`Warning: could not parse docs/plan.slices.yml: ${err.message} — skipping in_scope check\n`);
+  }
+  if (slicesDoc?.slices) {
+    allGlobs = slicesDoc.slices.flatMap(s => s.touched_paths ?? []);
+  }
+}
+
+for (const finding of findings) {
+  const locPath = finding.location?.path;
+  if (!locPath) continue; // no location → skip in_scope check for this finding
+  if (allGlobs === null) continue; // slices not available → skip
+
+  const matches = allGlobs.length > 0 && micromatch.isMatch(locPath, allGlobs);
+
+  if (finding.in_scope && !matches) {
+    process.stderr.write(
+      `Error: finding "${finding.id}" has in_scope=true but location.path "${locPath}" does not match any slice's touched_paths\n`
+    );
+    failed = true;
+  } else if (!finding.in_scope && matches) {
+    process.stderr.write(
+      `Error: finding "${finding.id}" has in_scope=false but location.path "${locPath}" matches a slice glob\n`
+    );
+    failed = true;
+  }
+}
+
+if (failed) process.exit(1);
+
+process.stdout.write(`validate-findings: OK (${findings.length} finding${findings.length === 1 ? '' : 's'})\n`);
+process.exit(0);

--- a/scripts/validate-slice-dag.js
+++ b/scripts/validate-slice-dag.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * validate-slice-dag <path>
+ *
+ * Validates that semantic_depends_on in docs/plan.slices.yml is acyclic, and
+ * that no file-overlap edges (entries without a `reason` field) have been
+ * removed compared to what derive-file-dag last wrote.
+ *
+ * The "tamper" check works against a lock-file: .groove-file-dag-lock.json
+ * written by derive-file-dag alongside plan.slices.yml. If the lock file
+ * doesn't exist the tamper check is skipped with a warning.
+ *
+ * Exits 0 on success, non-zero on any failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const [,, filePath] = process.argv;
+
+if (!filePath) {
+  process.stderr.write('Usage: validate-slice-dag <path-to-plan.slices.yml>\n');
+  process.exit(1);
+}
+
+const absPath = path.resolve(filePath);
+
+if (!fs.existsSync(absPath)) {
+  process.stderr.write(`Error: file not found: ${absPath}\n`);
+  process.exit(1);
+}
+
+let doc;
+try {
+  const raw = fs.readFileSync(absPath, 'utf8');
+  doc = yaml.load(raw);
+} catch (err) {
+  process.stderr.write(`Error: could not parse YAML: ${err.message}\n`);
+  process.exit(1);
+}
+
+if (!doc || !Array.isArray(doc.slices)) {
+  process.stderr.write('Error: invalid slices file — missing top-level "slices" array\n');
+  process.exit(1);
+}
+
+const slices = doc.slices;
+let failed = false;
+
+// ── Cycle detection (DFS) ────────────────────────────────────────────────────
+
+const adj = new Map(); // id → [dep-ids]
+for (const slice of slices) {
+  adj.set(slice.id, (slice.semantic_depends_on ?? []).map(d => d.id));
+}
+
+const WHITE = 0, GRAY = 1, BLACK = 2;
+const color = new Map();
+for (const id of adj.keys()) color.set(id, WHITE);
+
+function dfs(id, stack) {
+  color.set(id, GRAY);
+  stack.push(id);
+  for (const dep of adj.get(id) ?? []) {
+    if (color.get(dep) === GRAY) {
+      const cycleStart = stack.indexOf(dep);
+      const cycle = [...stack.slice(cycleStart), dep].join(' → ');
+      process.stderr.write(`Error: cycle detected: ${cycle}\n`);
+      failed = true;
+      // continue so we can catch more cycles
+    } else if (color.get(dep) === WHITE) {
+      dfs(dep, stack);
+    }
+  }
+  stack.pop();
+  color.set(id, BLACK);
+}
+
+for (const id of adj.keys()) {
+  if (color.get(id) === WHITE) dfs(id, []);
+}
+
+// ── Tamper check: file-overlap edges must not have been removed ──────────────
+
+const lockPath = path.join(path.dirname(absPath), '.groove-file-dag-lock.json');
+
+if (!fs.existsSync(lockPath)) {
+  process.stderr.write('Warning: .groove-file-dag-lock.json not found — skipping file-overlap edge tamper check\n');
+} else {
+  let lock;
+  try {
+    lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  } catch (err) {
+    process.stderr.write(`Warning: could not parse lock file: ${err.message} — skipping tamper check\n`);
+    lock = null;
+  }
+
+  if (lock) {
+    // lock: { [sliceId]: string[] }  — list of dependency slice ids that are file-overlap edges
+    const currentEdges = new Map();
+    for (const slice of slices) {
+      const overlapIds = (slice.semantic_depends_on ?? [])
+        .filter(d => !d.reason)
+        .map(d => d.id);
+      currentEdges.set(slice.id, new Set(overlapIds));
+    }
+
+    for (const [sliceId, lockedDepIds] of Object.entries(lock)) {
+      const current = currentEdges.get(sliceId) ?? new Set();
+      for (const depId of lockedDepIds) {
+        if (!current.has(depId)) {
+          process.stderr.write(
+            `Error: file-overlap edge removed — slice "${sliceId}" no longer has file-overlap dependency "${depId}"\n`
+          );
+          failed = true;
+        }
+      }
+    }
+  }
+}
+
+if (failed) process.exit(1);
+
+process.stdout.write(`validate-slice-dag: OK (${slices.length} slice${slices.length === 1 ? '' : 's'}, acyclic)\n`);
+process.exit(0);

--- a/scripts/validate-slices.js
+++ b/scripts/validate-slices.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * validate-slices <path>
+ *
+ * Validates docs/plan.slices.yml against the §1 slice schema.
+ * Extra checks beyond JSON Schema:
+ *   - All slice ids are unique
+ *   - Every dependency.id references a real slice id
+ *   - id matches ^[a-z0-9]+(-[a-z0-9]+)*$  (already in schema pattern, belt-and-suspenders)
+ *
+ * Exits 0 on success, non-zero on any failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const [,, filePath] = process.argv;
+
+if (!filePath) {
+  process.stderr.write('Usage: validate-slices <path-to-plan.slices.yml>\n');
+  process.exit(1);
+}
+
+const absPath = path.resolve(filePath);
+
+if (!fs.existsSync(absPath)) {
+  process.stderr.write(`Error: file not found: ${absPath}\n`);
+  process.exit(1);
+}
+
+let doc;
+try {
+  const raw = fs.readFileSync(absPath, 'utf8');
+  doc = yaml.load(raw);
+} catch (err) {
+  process.stderr.write(`Error: could not parse YAML: ${err.message}\n`);
+  process.exit(1);
+}
+
+// ── JSON Schema ──────────────────────────────────────────────────────────────
+
+const SLICE_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'groove/slice.schema.json',
+  title: 'Slice list',
+  type: 'object',
+  required: ['slices'],
+  additionalProperties: false,
+  properties: {
+    slices: {
+      type: 'array',
+      minItems: 1,
+      items: { $ref: '#/$defs/slice' },
+    },
+  },
+  $defs: {
+    slice: {
+      type: 'object',
+      required: ['id', 'title', 'acceptance_criteria', 'touched_paths', 'semantic_depends_on', 'out_of_scope'],
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+          pattern: '^[a-z0-9]+(-[a-z0-9]+)*$',
+        },
+        title: { type: 'string', minLength: 1, maxLength: 120 },
+        acceptance_criteria: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+        },
+        touched_paths: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
+        },
+        semantic_depends_on: {
+          type: 'array',
+          items: { $ref: '#/$defs/dependency' },
+        },
+        out_of_scope: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    },
+    dependency: {
+      type: 'object',
+      required: ['id'],
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string' },
+        reason: { type: 'string' },
+      },
+    },
+  },
+};
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+const validate = ajv.compile(SLICE_SCHEMA);
+
+const valid = validate(doc);
+if (!valid) {
+  for (const err of validate.errors) {
+    process.stderr.write(`Schema error at ${err.instancePath || '(root)'}: ${err.message}\n`);
+    if (err.params) {
+      const detail = JSON.stringify(err.params);
+      if (detail !== '{}') process.stderr.write(`  params: ${detail}\n`);
+    }
+  }
+  process.exit(1);
+}
+
+// ── Extra checks ─────────────────────────────────────────────────────────────
+
+const slices = doc.slices;
+const ids = new Set();
+let failed = false;
+
+for (const slice of slices) {
+  // Unique id check
+  if (ids.has(slice.id)) {
+    process.stderr.write(`Error: duplicate slice id "${slice.id}"\n`);
+    failed = true;
+  }
+  ids.add(slice.id);
+}
+
+// Reference check (all dependency.id values must exist)
+for (const slice of slices) {
+  for (const dep of slice.semantic_depends_on ?? []) {
+    if (!ids.has(dep.id)) {
+      process.stderr.write(`Error: slice "${slice.id}" has dependency "${dep.id}" which does not exist\n`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+
+process.stdout.write(`validate-slices: OK (${slices.length} slice${slices.length === 1 ? '' : 's'})\n`);
+process.exit(0);

--- a/scripts/validate-substrate-coverage.js
+++ b/scripts/validate-substrate-coverage.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * validate-substrate-coverage <dir>
+ *
+ * For each substrate type directory, checks bidirectional coverage:
+ *   - Every .md file (excluding INDEX.md) has a row in INDEX.md
+ *   - Every row in INDEX.md has a corresponding .md file
+ *
+ * INDEX.md row format: | ID | Description | Path | ...
+ * The "Path" column value is matched against the filename.
+ *
+ * Exits 0 on success (including type dirs with only INDEX.md), non-zero on failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const [,, dirPath] = process.argv;
+
+if (!dirPath) {
+  process.stderr.write('Usage: validate-substrate-coverage <path-to-.substrate/>\n');
+  process.exit(1);
+}
+
+const absDir = path.resolve(dirPath);
+
+if (!fs.existsSync(absDir)) {
+  process.stderr.write(`Error: directory not found: ${absDir}\n`);
+  process.exit(1);
+}
+
+const KNOWN_TYPES = ['vocabulary', 'adr', 'anti-pattern', 'solution', 'reviewers'];
+
+let failed = false;
+let typeCount = 0;
+
+for (const typeDirName of KNOWN_TYPES) {
+  const typeDir = path.join(absDir, typeDirName);
+  if (!fs.existsSync(typeDir)) continue;
+  typeCount++;
+
+  const indexPath = path.join(typeDir, 'INDEX.md');
+
+  // Collect entry files (all .md except INDEX.md)
+  const allEntries = fs.readdirSync(typeDir)
+    .filter(f => f.endsWith('.md') && f !== 'INDEX.md');
+
+  // If no INDEX.md and no entry files, that's fine
+  if (!fs.existsSync(indexPath)) {
+    if (allEntries.length > 0) {
+      for (const entry of allEntries) {
+        process.stderr.write(
+          `Error: ${typeDir}/${entry}: file exists but ${typeDirName}/INDEX.md is missing\n`
+        );
+        failed = true;
+      }
+    }
+    continue;
+  }
+
+  // Parse INDEX.md to extract Path column values
+  const indexContent = fs.readFileSync(indexPath, 'utf8');
+  const indexRows = parseIndexPaths(indexContent, typeDir);
+
+  // Bidirectional check
+  // 1. Every entry file must have a matching row
+  for (const entryFile of allEntries) {
+    const entryBasename = entryFile;
+    const normalized = `./${entryBasename}`;
+    const found = indexRows.some(row => {
+      const rowPath = row.replace(/^\.\//, '');
+      const rowBase = path.basename(rowPath);
+      return rowBase === entryBasename || rowPath === entryBasename || row === normalized;
+    });
+    if (!found) {
+      process.stderr.write(
+        `Error: ${typeDir}/${entryFile}: file exists but has no row in INDEX.md\n`
+      );
+      failed = true;
+    }
+  }
+
+  // 2. Every INDEX.md row must have a corresponding file
+  for (const rowPath of indexRows) {
+    // rowPath is relative to the type dir, e.g. "./workspace.md"
+    const normalized = rowPath.replace(/^\.\//, '');
+    const fullPath = path.join(typeDir, normalized);
+    if (!fs.existsSync(fullPath)) {
+      process.stderr.write(
+        `Error: INDEX.md in ${typeDir} references "${rowPath}" but file does not exist\n`
+      );
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+
+process.stdout.write(
+  `validate-substrate-coverage: OK (${typeCount} type director${typeCount === 1 ? 'y' : 'ies'} checked)\n`
+);
+process.exit(0);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse all "Path" column values from an INDEX.md markdown table.
+ * Returns an array of path strings.
+ */
+function parseIndexPaths(content, typeDir) {
+  const paths = [];
+  const lines = content.split('\n');
+
+  // Find the header row to locate the "Path" column index
+  let pathColIndex = -1;
+  let headerFound = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('|')) continue;
+
+    const cells = trimmed.split('|').map(c => c.trim()).filter(Boolean);
+
+    if (!headerFound) {
+      // Find header row
+      const lowerCells = cells.map(c => c.toLowerCase());
+      const pIdx = lowerCells.indexOf('path');
+      if (pIdx !== -1) {
+        pathColIndex = pIdx;
+        headerFound = true;
+      }
+      continue;
+    }
+
+    // Skip separator row (--- cells)
+    if (cells.every(c => c.match(/^[-:]+$/))) continue;
+
+    // Data row
+    if (pathColIndex >= 0 && cells.length > pathColIndex) {
+      const cellVal = cells[pathColIndex].trim();
+      if (cellVal) paths.push(cellVal);
+    }
+  }
+
+  // Fallback: if no Path column found, try the last column (common convention)
+  if (pathColIndex === -1) {
+    let inTable = false;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('|')) { inTable = false; continue; }
+      const cells = trimmed.split('|').map(c => c.trim()).filter(Boolean);
+      if (!inTable) {
+        // Check for header
+        if (cells.some(c => c.toLowerCase() === 'id')) {
+          inTable = true;
+        }
+        continue;
+      }
+      if (cells.every(c => c.match(/^[-:]+$/))) continue;
+      const last = cells[cells.length - 1];
+      if (last && last.endsWith('.md')) paths.push(last);
+    }
+  }
+
+  return paths;
+}

--- a/scripts/validate-substrate.js
+++ b/scripts/validate-substrate.js
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * validate-substrate <dir>
+ *
+ * For every .md file in .substrate/<type>/ directories, parses YAML frontmatter
+ * and validates against the per-type schema (§4a–4f). Also enforces Markdown
+ * section conventions:
+ *   - ADR must have ## Summary, ## Context, ## Decision, ## Alternatives considered,
+ *     ## Consequences
+ *   - anti-pattern body must contain the rule (never ...), reason (because ...), and
+ *     a positive example (## Example or "For example" or similar)
+ *
+ * Exits 0 on success (including empty directory), non-zero on any failure.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const [,, dirPath] = process.argv;
+
+if (!dirPath) {
+  process.stderr.write('Usage: validate-substrate <path-to-.substrate/>\n');
+  process.exit(1);
+}
+
+const absDir = path.resolve(dirPath);
+
+if (!fs.existsSync(absDir)) {
+  process.stderr.write(`Error: directory not found: ${absDir}\n`);
+  process.exit(1);
+}
+
+// ── JSON Schemas ─────────────────────────────────────────────────────────────
+
+const BASE_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'groove/substrate-frontmatter-base.schema.json',
+  type: 'object',
+  required: ['id', 'type', 'description', 'created'],
+  properties: {
+    id: { type: 'string', pattern: '^[a-z0-9]+(-[a-z0-9]+)*$' },
+    type: { type: 'string', enum: ['vocabulary', 'adr', 'anti-pattern', 'solution', 'reviewer'] },
+    description: { type: 'string', minLength: 1, maxLength: 200 },
+    created: { type: 'string', format: 'date' },
+    supersedes: { type: 'array', items: { type: 'string' } },
+    tags: { type: 'array', items: { type: 'string' } },
+  },
+};
+
+const ADR_SCHEMA = {
+  allOf: [
+    BASE_SCHEMA,
+    {
+      type: 'object',
+      properties: {
+        type: { const: 'adr' },
+        status: { type: 'string', enum: ['accepted', 'superseded', 'deprecated'] },
+      },
+      required: ['status'],
+    },
+  ],
+};
+
+const ANTI_PATTERN_SCHEMA = {
+  allOf: [
+    BASE_SCHEMA,
+    {
+      type: 'object',
+      properties: {
+        type: { const: 'anti-pattern' },
+        scope: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
+        },
+      },
+      required: ['scope'],
+    },
+  ],
+};
+
+const SOLUTION_SCHEMA = {
+  allOf: [
+    BASE_SCHEMA,
+    {
+      type: 'object',
+      properties: {
+        type: { const: 'solution' },
+        scope: { type: 'array', items: { type: 'string' } },
+        tags: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string' },
+        },
+        worked_example_url: { type: 'string', format: 'uri' },
+      },
+      required: ['tags'],
+    },
+  ],
+};
+
+// Predicate DSL schema (inline, self-contained with recursive $ref: '#')
+const PREDICATE_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://groove/predicate.schema.json',
+  oneOf: [
+    { $ref: '#/$defs/leaf' },
+    { $ref: '#/$defs/composite' },
+  ],
+  $defs: {
+    leaf: {
+      type: 'object',
+      oneOf: [
+        {
+          required: ['paths'],
+          additionalProperties: false,
+          properties: { paths: { type: 'array', items: { type: 'string' } } },
+        },
+        {
+          required: ['new_files_in'],
+          additionalProperties: false,
+          properties: { new_files_in: { type: 'array', items: { type: 'string' } } },
+        },
+        {
+          required: ['diff_contains'],
+          additionalProperties: false,
+          properties: { diff_contains: { type: 'array', items: { type: 'string' } } },
+        },
+        {
+          required: ['always'],
+          additionalProperties: false,
+          properties: { always: { type: 'boolean', const: true } },
+        },
+      ],
+    },
+    composite: {
+      type: 'object',
+      oneOf: [
+        {
+          required: ['any'],
+          additionalProperties: false,
+          properties: { any: { type: 'array', minItems: 1, items: { $ref: 'https://groove/predicate.schema.json' } } },
+        },
+        {
+          required: ['all'],
+          additionalProperties: false,
+          properties: { all: { type: 'array', minItems: 1, items: { $ref: 'https://groove/predicate.schema.json' } } },
+        },
+        {
+          required: ['not'],
+          additionalProperties: false,
+          properties: { not: { $ref: 'https://groove/predicate.schema.json' } },
+        },
+      ],
+    },
+  },
+};
+
+const REVIEWER_SCHEMA = {
+  allOf: [
+    BASE_SCHEMA,
+    {
+      type: 'object',
+      properties: {
+        type: { const: 'reviewer' },
+        predicate: { $ref: 'https://groove/predicate.schema.json' },
+        priority_floor: { type: 'string', enum: ['P1', 'P2', 'P3'] },
+        category: { type: 'string' },
+      },
+      required: ['predicate', 'category'],
+    },
+  ],
+};
+
+// vocabulary uses the base schema unchanged
+const VOCABULARY_SCHEMA = BASE_SCHEMA;
+
+const SCHEMAS_BY_TYPE = {
+  vocabulary: VOCABULARY_SCHEMA,
+  adr: ADR_SCHEMA,
+  'anti-pattern': ANTI_PATTERN_SCHEMA,
+  solution: SOLUTION_SCHEMA,
+  reviewer: REVIEWER_SCHEMA,
+};
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+// Add predicate schema so $ref works
+ajv.addSchema(PREDICATE_SCHEMA);
+
+const validators = {};
+for (const [type, schema] of Object.entries(SCHEMAS_BY_TYPE)) {
+  validators[type] = ajv.compile(schema);
+}
+
+// ── Frontmatter parser ───────────────────────────────────────────────────────
+
+function parseFrontmatter(content) {
+  // YAML frontmatter is between the first pair of --- delimiters
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { frontmatterRaw: null, body: content };
+  return { frontmatterRaw: match[1], body: match[2] };
+}
+
+// ── Walk the substrate directory ─────────────────────────────────────────────
+
+// Known substrate type directories
+const KNOWN_TYPES = ['vocabulary', 'adr', 'anti-pattern', 'solution', 'reviewers'];
+
+let failed = false;
+let fileCount = 0;
+
+// Collect all .md files in each type directory (excluding INDEX.md)
+for (const typeDirName of KNOWN_TYPES) {
+  const typeDir = path.join(absDir, typeDirName);
+  if (!fs.existsSync(typeDir)) continue;
+
+  // Map directory name to schema type (reviewers dir → reviewer type)
+  const schemaType = typeDirName === 'reviewers' ? 'reviewer' : typeDirName;
+
+  const entries = fs.readdirSync(typeDir);
+  for (const entry of entries) {
+    if (!entry.endsWith('.md') || entry === 'INDEX.md') continue;
+    const filePath = path.join(typeDir, entry);
+    const content = fs.readFileSync(filePath, 'utf8');
+    fileCount++;
+
+    const { frontmatterRaw, body } = parseFrontmatter(content);
+    if (!frontmatterRaw) {
+      process.stderr.write(`Error: ${filePath}: missing YAML frontmatter\n`);
+      failed = true;
+      continue;
+    }
+
+    // Parse YAML frontmatter
+    // Use JSON_SCHEMA to prevent js-yaml from auto-parsing dates as Date objects
+    let fm;
+    try {
+      fm = yaml.load(frontmatterRaw, { schema: yaml.JSON_SCHEMA });
+    } catch (err) {
+      process.stderr.write(`Error: ${filePath}: invalid YAML frontmatter: ${err.message}\n`);
+      failed = true;
+      continue;
+    }
+
+    if (typeof fm !== 'object' || fm === null) {
+      process.stderr.write(`Error: ${filePath}: frontmatter is not a YAML object\n`);
+      failed = true;
+      continue;
+    }
+
+    // Validate type field matches directory
+    if (fm.type !== schemaType) {
+      process.stderr.write(
+        `Error: ${filePath}: frontmatter type "${fm.type}" does not match directory type "${schemaType}"\n`
+      );
+      failed = true;
+    }
+
+    // Validate against the appropriate schema
+    const validator = validators[schemaType];
+    if (!validator) {
+      process.stderr.write(`Warning: ${filePath}: unknown substrate type "${schemaType}" — skipping schema check\n`);
+      continue;
+    }
+
+    const valid = validator(fm);
+    if (!valid) {
+      for (const err of validator.errors) {
+        process.stderr.write(
+          `Error: ${filePath}: frontmatter schema error at ${err.instancePath || '(root)'}: ${err.message}\n`
+        );
+      }
+      failed = true;
+    }
+
+    // ── Markdown body conventions ──────────────────────────────────────────
+
+    if (schemaType === 'adr') {
+      const required = ['## Summary', '## Context', '## Decision', '## Alternatives considered', '## Consequences'];
+      for (const section of required) {
+        if (!body.includes(section)) {
+          process.stderr.write(`Error: ${filePath}: ADR body is missing section "${section}"\n`);
+          failed = true;
+        }
+      }
+    }
+
+    if (schemaType === 'anti-pattern') {
+      // Must state the rule (never X), reason (because Y), and a positive example
+      const bodyLower = body.toLowerCase();
+      if (!bodyLower.includes('never ') && !bodyLower.includes('do not ') && !bodyLower.includes('avoid ')) {
+        process.stderr.write(
+          `Error: ${filePath}: anti-pattern body must state the rule (include "never", "do not", or "avoid")\n`
+        );
+        failed = true;
+      }
+      if (!bodyLower.includes('because ') && !bodyLower.includes('reason') && !bodyLower.includes('why')) {
+        process.stderr.write(
+          `Error: ${filePath}: anti-pattern body must state the reason (include "because", "reason", or "why")\n`
+        );
+        failed = true;
+      }
+      if (
+        !bodyLower.includes('for example') &&
+        !bodyLower.includes('example:') &&
+        !body.includes('## Example') &&
+        !body.includes('## Positive example') &&
+        !body.includes('## Instead') &&
+        !body.includes('## Do this instead')
+      ) {
+        process.stderr.write(
+          `Error: ${filePath}: anti-pattern body must include a positive example\n`
+        );
+        failed = true;
+      }
+    }
+  }
+}
+
+if (failed) process.exit(1);
+
+process.stdout.write(`validate-substrate: OK (${fileCount} file${fileCount === 1 ? '' : 's'} checked)\n`);
+process.exit(0);


### PR DESCRIPTION
Implements #34.

## Summary
- Adds `scripts/` workspace package (`@groove/scripts`) with bin entries for all 6 validators and `derive-file-dag`
- Adds `package.json` workspace root and `pnpm-workspace.yaml`
- All scripts callable via `pnpm exec <name>` from any project consuming the package
- Schemas sourced from `docs/schemas-and-conventions.md`; validation powered by ajv@8

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)